### PR TITLE
bug/DS-96-button-browser-support

### DIFF
--- a/projects/front-end-library/src/lib/components/button/scss/index.scss
+++ b/projects/front-end-library/src/lib/components/button/scss/index.scss
@@ -84,7 +84,7 @@
     }
 
     &--fullwidth {
-        @extend .w-100;
+        @extend .w-100; // bootstrap class makes it !important change to width:100% if necessary only
     }
 
     &.loading {
@@ -123,8 +123,20 @@
         display: flex;
         justify-content: center;
         align-items: center;
-        gap: .5rem;
         white-space: nowrap;
+        .bf-icon { 
+            margin-right: .5rem;
+            &.bf-button__icon--right { 
+                margin-right: 0;margin-left: .5rem;
+            }
+        }
+        @supports (gap: 0.5rem){
+            gap: 0.5rem;
+            .bf-icon, 
+            .bf-icon.bf-button__icon--right { 
+                margin: 0
+            }
+        }
     }
 
     &__icon--right {

--- a/projects/front-end-library/src/lib/components/button/scss/index.scss
+++ b/projects/front-end-library/src/lib/components/button/scss/index.scss
@@ -130,13 +130,6 @@
                 margin-right: 0;margin-left: .5rem;
             }
         }
-        @supports (gap: 0.5rem){
-            gap: 0.5rem;
-            .bf-icon, 
-            .bf-icon.bf-button__icon--right { 
-                margin: 0
-            }
-        }
     }
 
     &__icon--right {


### PR DESCRIPTION
gap est plus élégant qu'une marge qui change de place en fonction de la position de l'icône
tenté d'ajouter le @supports pour utiliser gap quand le navigateur le supporte mais safari croit le supporter.

à tester. ça fonctionnait bien sur iPad 14.7.1 avec Safari mais je reproduit le bug avec mon ipod (ios 12.5.4)

![image](https://user-images.githubusercontent.com/82388009/130130628-93d632b1-4215-40e5-b245-5523522ebd89.png)
