### PR TITLE
DS-274 - card - fix list separator

### DIFF
--- a/CHANGELOG.mdx
+++ b/CHANGELOG.mdx
@@ -3,6 +3,8 @@
 <br/><br/>
 
 ## Next Version vX.X.X
+### Cards
+- Improved [card-plan](/?path=/story/components-card--drupal-plan/?path=/story/components-card--drupal-plan) by adding list separators
 
 ### Tiles Post
 - New [Tile Post](?path=/story/components-tile-post--drupal) twig compopent

--- a/projects/front-end-library/src/lib/components/card/scss/index.scss
+++ b/projects/front-end-library/src/lib/components/card/scss/index.scss
@@ -18,7 +18,7 @@
         background-color: transparent;
     }
     &--plan {
-        .bf-card__content-list:last-child li:last-of-type {
+        .bf-card__content-list {
             @extend .border-bottom;
             @extend .bf-border-color-secondary;
             @extend .pb-3

--- a/projects/front-end-library/src/lib/components/card/twig/index.twig
+++ b/projects/front-end-library/src/lib/components/card/twig/index.twig
@@ -108,7 +108,7 @@
     {% block card_body %}
       {% if contentLists is defined and contentLists %}
         {% for list in contentLists %}
-          <div class='bf-card__content-list pt-3 px-3 px-sm-4'>
+          <div class='bf-card__content-list pt-3 mx-3 mx-sm-4'>
             {% if list.title is defined %}
               <div class='d-flex mb-2'>
                 <p class='w-60 bf-text font-weight-bold mb-0'>


### PR DESCRIPTION
@JonathanLefebvreV  
le CSS pour le séparateur existait déjà dans le card mais était buggué. je l'ai simplement réparé 
meilleur quick win à mon avis. 

Pas question de list Ici - je vais transformer la sous-tâche List en idée jira  - on en reparlera au weekly. il n'y plus d'urgence. 