### PR TITLE
DS-306 Mega Menu - bug fix when no Mega Items

### DIFF
--- a/CHANGELOG.mdx
+++ b/CHANGELOG.mdx
@@ -3,9 +3,11 @@
 <br/><br/>
 
 ## Next Version vX.X.X
+###Bug fix
+- Fix MegaMenu in [Navigation Header](/?path=/docs/components-navigation-header--drupal) twig component
 
 ### Tiles Post
-- New [Tile Post](?path=/story/components-tile-post--drupal) twig compopent
+- New [Tile Post](?path=/story/components-tile-post--drupal) twig component
 - New [Tiles Post](?path=/story/sections-tiles-post--drupal) twig section
 
 ### UI-Kit (migrations)

--- a/projects/front-end-library/src/lib/components/navigation-header/twig/mega-menu.twig
+++ b/projects/front-end-library/src/lib/components/navigation-header/twig/mega-menu.twig
@@ -75,7 +75,7 @@
                             {% endfor %}
                         </div>
 
-                        <div class="tab-content" id="v-pills-tabContent">
+                        <div class="tab-content flex-1" id="v-pills-tabContent">
                             <!-- TAB : pane -->
                             {% for dropdownSubItem in navItem.subItemsMultiDropdown %}
 
@@ -89,7 +89,7 @@
                                      role="tabpanel"
                                      aria-labelledby="v-pills-{{ dropdownSubItem.catLabel|default('category')|url_encode }}-tab"
                                 >
-                                    <div class="p-dropdown-megamenu js-bf-dropdown-megamenu h-100 d-flex flex-column justify-content-between p-3 py-md-4 px-md-5">
+                                    <div class="p-dropdown-megamenu js-bf-dropdown-megamenu h-100 d-flex flex-column justify-content-between p-3 py-md-4 px-md-5 flex-1">
                                         <div class="row">
                                             {% for subItem in dropdownSubItem.subdropdownItems %}
                                                 {% set fullWidth = subItem.isFullWidth ? 'col-lg-12' : 'col-lg-3'  %}


### PR DESCRIPTION
Pour tester retirer le bloc avec les Mega Itemps dans l'inspecteur de document - le Méga Menu n'est pas bifrostisé
https://bifrost-front-end-library-git-ds-306-mega-me-3fd466-bifrost-vui.vercel.app/?path=/story/components-navigation-header--drupal