### PR TITLE
Ds 321 input submit

### DIFF
--- a/CHANGELOG.mdx
+++ b/CHANGELOG.mdx
@@ -8,6 +8,9 @@
 - Fix `disabled`property of [Button Icon](/docs/components-button-icon--drupal) Twig component
 - Fix components visual bugs on both states **Reversed** and **Highlight** (ex: Hero). See [improved documentation](/docs/implementation-reversed-highlight--page).
 
+### Input Submit
+- Added [Twig Component Input Submit](/story/components-input-submit--drupal)
+
 ### Icons
 - Export [Angular Component Icon](/story/components-icon--angular-interface) in Angular Library.
 - Improved [icon Illustration library](/story/components-icon--drupal-illustration) accessibility by adding `role="img"` to SVGs

--- a/projects/front-end-library/src/lib/components/input-submit/_doc/doc.stories.mdx
+++ b/projects/front-end-library/src/lib/components/input-submit/_doc/doc.stories.mdx
@@ -1,0 +1,111 @@
+import { moduleMetadata }  from '@storybook/angular';
+import { Canvas, Meta, Story, ArgsTable } from '@storybook/addon-docs';
+import { withDesign } from 'storybook-addon-designs';
+import interfaceIcons  from '../../../../../../../public/icons/list/interfaces.json';
+import { TwigContainerComponent } from '../../../../utils/twig-container/twig-container.component';
+import { InputSubmitComponent } from '../angular/input-submit.component';
+
+<Meta
+    title='Components/Input Submit'
+    component={InputSubmitComponent}
+    decorators={[
+        moduleMetadata({ declarations: [InputSubmitComponent, TwigContainerComponent]}),
+        withDesign
+    ]}
+    parameters={{
+        design: {
+            type: 'figma',
+            url: 'https://www.figma.com/file/FkPUN7xRQi0wJrXXdDIoO4/DS-Library-DONT-YOU-DARE-USING-IT?node-id=3240%3A619',
+            disable: false
+        },
+    }}
+    argTypes={{
+        _background: {
+            control: {
+                type: 'select',
+                options: ['', 'bf-color-bg-ground', 'bf-color-bg-underground', 'reversed bf-color-bg-ground', 'reversed bf-color-bg-underground', 'bf-color-bg-highlight']
+            },
+            description: 'Preview the component on selected background'
+        },
+        hierarchy: {
+            defaultValue: 'primary',
+            table : { defaultValue: { summary: 'primary' } },
+            control: { type: 'select' }
+        },
+        iconName: {
+            defaultValue: null,
+            table : { defaultValue: { summary: 'null' } },
+            control: {
+                type: 'select',
+                options: [null, 'placeholder', ...interfaceIcons.map(a => a.list).flat().sort()]
+            }
+        },
+        iconPosition: {
+            defaultValue: null,
+            table: { defaultValue: { summary: 'null' } },
+            control: { type: 'select' }
+        },
+        formEncryptionType: {
+            defaultValue: null,
+            table: { defaultValue: { summary: 'null' } },
+            control: { type: 'select' }
+        },
+        formTarget: {
+            defaultValue: null,
+            table: { defaultValue: { summary: 'null' } },
+            control: { type: 'select' }
+        },
+        formNoValidate: {
+            defaultValue: false,
+            table: { defaultValue: { summary: false } },
+        },
+        autofocus: {
+            defaultValue: false,
+            table: { defaultValue: { summary: false } },
+        },
+        isDisabled: {
+            defaultValue: false,
+            table: { defaultValue: { summary: false } },
+        }
+    }}
+/>
+
+# Input Submit
+
+export const Drupal = (args) => ({
+    component   : TwigContainerComponent,
+    props       : args,
+});
+
+## Component API
+
+<ArgsTable of={InputSubmitComponent} />
+
+## Drupal
+
+<Canvas withSource='none'>
+    <Story
+        name='Drupal'
+        height='300px'
+        args={{
+            elementPath : 'components/input-submit/_doc/template.drupal',
+            label       : 'Input Submit',
+        }}
+    >
+        {Drupal.bind({})}
+    </Story>
+</Canvas>
+
+
+## Drupal implementation example
+
+```jsx
+{% include '@bf-components/input-submit/twig/index.twig' with {
+    // Add relevant props here
+} only %}
+```
+
+## Design Guidelines
+
+
+<iframe width='100%' height='450' src='https://www.figma.com/embed?embed_host=share&url=https%3A%2F%2Fwww.figma.com%2Ffile%2FFkPUN7xRQi0wJrXXdDIoO4%2FDS-Library-DONT-YOU-DARE-USING-IT%3Fnode-id%3D3240%253A619&chrome=DOCUMENTATION' frameBorder='0' allowFullScreen></iframe>

--- a/projects/front-end-library/src/lib/components/input-submit/_doc/doc.stories.mdx
+++ b/projects/front-end-library/src/lib/components/input-submit/_doc/doc.stories.mdx
@@ -100,8 +100,15 @@ export const Drupal = (args) => ({
 ## Drupal implementation example
 
 ```jsx
+// The button is in the form :
 {% include '@bf-components/input-submit/twig/index.twig' with {
-    // Add relevant props here
+    label: 'Submit form'
+} only %}
+
+//The button is outside the form
+{% include '@bf-components/input-submit/twig/index.twig' with {
+    label: 'Submit form',
+    formId: 'myform'
 } only %}
 ```
 

--- a/projects/front-end-library/src/lib/components/input-submit/_doc/template.drupal.twig
+++ b/projects/front-end-library/src/lib/components/input-submit/_doc/template.drupal.twig
@@ -1,0 +1,11 @@
+{% set isDisabled = isDisabled|json_parse %}
+{% set fullWidth = fullWidth|json_parse %}
+{% set autofocus = autofocus|json_parse %}
+{% set iconName = iconName|json_parse %}
+{% set formTarget = formTarget|json_parse %}
+{% set formEncryptionType = formEncryptionType|json_parse %}
+{% set formNoValidate = formNoValidate|json_parse %}
+
+<div class='pt-4 {% if reversed %}reversed bf-color-bg-ground{% endif %}'>
+    {% include '@bf-components/input-submit/twig/index.twig' %}
+</div>

--- a/projects/front-end-library/src/lib/components/input-submit/_doc/template.drupal.twig
+++ b/projects/front-end-library/src/lib/components/input-submit/_doc/template.drupal.twig
@@ -6,6 +6,6 @@
 {% set formEncryptionType = formEncryptionType|json_parse %}
 {% set formNoValidate = formNoValidate|json_parse %}
 
-<div class='pt-4 {% if reversed %}reversed bf-color-bg-ground{% endif %}'>
+<div class='p-4 {{ _background }}'>
     {% include '@bf-components/input-submit/twig/index.twig' %}
 </div>

--- a/projects/front-end-library/src/lib/components/input-submit/angular/input-submit.component.html
+++ b/projects/front-end-library/src/lib/components/input-submit/angular/input-submit.component.html
@@ -1,0 +1,1 @@
+Input Submit

--- a/projects/front-end-library/src/lib/components/input-submit/angular/input-submit.component.ts
+++ b/projects/front-end-library/src/lib/components/input-submit/angular/input-submit.component.ts
@@ -1,0 +1,35 @@
+import { Component, OnInit, Input } from '@angular/core';
+
+@Component({
+    selector: 'bf-input-submit',
+    templateUrl: './input-submit.component.html',
+})
+export class InputSubmitComponent implements OnInit {
+    constructor() {}
+
+    @Input() label: string;
+    @Input() id: string;
+    @Input() ariaLabel: string;
+    @Input() hierarchy: null | 'primary' | 'primary-alt' | 'secondary' | 'tertiary';
+    @Input() iconName: string;
+    @Input() iconPosition: null | 'left' | 'right';
+    @Input() fullWidth: boolean;
+
+    @Input() isDisabled: boolean;
+    @Input() autofocus: boolean;
+
+    @Input() formId: string;
+    @Input() formAction: string;
+    @Input() formEncryptionType: null | 'application/x-www-form-urlencoded' |'multipart/form-data' | 'text/plain';
+    @Input() formTarget: null | '_self' | '_blank' | '_parent' | '_top';
+    @Input() formMethod: string;
+    @Input() formNoValidate:boolean;
+
+
+    @Input() extraAttribute: string;
+    @Input() class: string;
+
+    ngOnInit() {
+        console.log('InputSubmit', this);
+    }
+}

--- a/projects/front-end-library/src/lib/components/input-submit/angular/input-submit.module.ts
+++ b/projects/front-end-library/src/lib/components/input-submit/angular/input-submit.module.ts
@@ -1,0 +1,9 @@
+import { NgModule } from '@angular/core';
+import { InputSubmitComponent } from './input-submit.component';
+
+@NgModule({
+    declarations: [InputSubmitComponent],
+    imports: [],
+    exports: [InputSubmitComponent]
+})
+export class InputSubmitModule { }

--- a/projects/front-end-library/src/lib/components/input-submit/twig/index.twig
+++ b/projects/front-end-library/src/lib/components/input-submit/twig/index.twig
@@ -1,4 +1,4 @@
-<button class=' bf-button bf-button--{{ hierarchy|default('primary') }} {{ isDisabled|default(false) ? 'disabled' }} {{  fullWidth|default(false) ?'bf-button--fullwidth' }}'
+<button class=' bf-button bf-button--{{ hierarchy|default('primary') }} {{ isDisabled|default(false) ? 'disabled' }} {{  fullWidth|default(false) ?'bf-button--fullwidth' }} {{ class|default(null) }}'
         type='submit'
         aria-label='{{ ariaLabel|default(null)? }}'
         {% if id|default(null) %}  id='{{ id }}' {% endif %}

--- a/projects/front-end-library/src/lib/components/input-submit/twig/index.twig
+++ b/projects/front-end-library/src/lib/components/input-submit/twig/index.twig
@@ -1,0 +1,29 @@
+<button class=' bf-button bf-button--{{ hierarchy|default('primary') }} {{ isDisabled|default(false) ? 'disabled' }} {{  fullWidth|default(false) ?'bf-button--fullwidth' }}'
+        type='submit'
+        aria-label='{{ ariaLabel|default(null)? }}'
+        {% if id|default(null) %}  id='{{ id }}' {% endif %}
+        {{ isDisabled|default(false) ? 'disabled' }}
+        {{ autofocus|default(false) ? 'autofocus' }}
+        {% if formId|default(null) %}  form='{{ formId }}' {% endif %}
+        {% if formAction|default(null) %}  formaction='{{ formAction }}' {% endif %}
+        {% if formEncryptionType|default(null) %}  formenctype='{{ formEncryptionType }}' {% endif %}
+        {% if formTarget|default(null) %}  formtarget='{{ formTarget }}' {% endif %}
+        {% if formMethod|default(null) %}  formmethod='{{ formMethod }}' {% endif %}
+        {% if formNoValidate|default(false) %}  formnovalidate="formnovalidate" {% endif %}
+        {{ extraAttribute|default(null) ? extraAttribute }}
+>
+  <span class='bf-button__label'>
+  {% if iconName is defined and iconName %}
+    {% include '@bf-components/icon/twig/index.twig' with {
+      name: iconName,
+      size: 'small',
+      class: iconPosition is same as ('right') ? 'bf-button__icon--right' : ''
+    } only %}
+  {% endif %}
+    {% if label is defined and label %}
+      <span class='bf-button__label__text'>
+        {{ label }}
+      </span>
+    {% endif %}
+  </span>
+</button>


### PR DESCRIPTION
Nouveau composant Bifrost : Input Submit
Pas de CSS - Utilise le CSS du bouton bifrost
Choix du `<button> type='submit'>`  afin de permettre un icone comme tous les autres boutons (`<input>` ne le permet pas )
`<bouton>` peut être placé à l'extérieur du formulaire (`<input>` fonctionne avec `form='formId'` mais n'est pas structurellement valide)