### PR TITLE
DS-285 - hide control panel in example stories

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -13,7 +13,8 @@ addParameters({
     options: {
         storySort: {
             order: ['*', 'UI-Kit']
-        }
+        },
+        showPanel: true
     },
 
     docs: {
@@ -33,7 +34,6 @@ addParameters({
             { name: 'Underground Reversed', value: '#2a2a27' },
         ],
     },
-
     controls: {
         expanded: true,
         hideNoControlsWarning: true,

--- a/CHANGELOG.mdx
+++ b/CHANGELOG.mdx
@@ -3,6 +3,9 @@
 <br/><br/>
 
 ## [Next Version](https://bifrost-front-end-library-vui.vercel.app/)
+### Base
+- Hide the Storybook Control Panel on *Example* stories in Components and Sections. User may still activate Control Panel manually
+
 ### Bug fix
 - Fix `disabled` property of [Button Icon](/story/components-button-icon--drupal) Twig component
 - Fix components visual bugs on both states **Reversed** and **Highlight** (ex: Hero). See [improved documentation](/docs/implementation-reversed-highlight--page).

--- a/CHANGELOG.mdx
+++ b/CHANGELOG.mdx
@@ -3,9 +3,6 @@
 <br/><br/>
 
 ## [Next Version](https://bifrost-front-end-library-vui.vercel.app/)
-### Base
-- Hide the Storybook Control Panel on *Example* stories in Components and Sections. User may still activate Control Panel manually
-
 ### Bug fix
 - Fix `disabled` property of [Button Icon](/story/components-button-icon--drupal) Twig component
 - Fix components visual bugs on both states **Reversed** and **Highlight** (ex: Hero). See [improved documentation](/docs/implementation-reversed-highlight--page).

--- a/projects/front-end-library/src/lib/components/block-highlight/_doc/doc.stories.mdx
+++ b/projects/front-end-library/src/lib/components/block-highlight/_doc/doc.stories.mdx
@@ -100,10 +100,11 @@ export const commonProps = {
     <Story
         name='Drupal - Usage example'
         height='800px'
+        parameters={{ options: { showPanel: false } }}
         args={{
             ...commonProps,
             elementPath : 'components/block-highlight/_doc/template-usage-example.drupal',
-            image       : null
+            image: null,
         }}
     >
         {Drupal.bind({})}

--- a/projects/front-end-library/src/lib/components/breadcrumb/_doc/doc.stories.mdx
+++ b/projects/front-end-library/src/lib/components/breadcrumb/_doc/doc.stories.mdx
@@ -47,6 +47,7 @@ export const Drupal = (args) => ({
     <Story
         name='Drupal'
         height='400px'
+        parameters={{ options: { showPanel: false } }}
         args={{
             elementPath     : 'components/breadcrumb/_doc/template.drupal',
         }}

--- a/projects/front-end-library/src/lib/components/button-nav/_doc/doc.stories.mdx
+++ b/projects/front-end-library/src/lib/components/button-nav/_doc/doc.stories.mdx
@@ -73,6 +73,7 @@ export const Drupal = (args) => ({
     <Story
         name='Drupal - Usage Example'
         height='900px'
+        parameters={{ options: { showPanel: false } }}
         args={{
             elementPath : 'components/button-nav/_doc/usage-example.drupal'
         }}

--- a/projects/front-end-library/src/lib/components/button/_doc/doc.stories.mdx
+++ b/projects/front-end-library/src/lib/components/button/_doc/doc.stories.mdx
@@ -96,6 +96,7 @@ export const Drupal = (args) => ({
     <Story
         name='Drupal - CSS only'
         height='700px'
+        parameters={{ options: { showPanel: false } }}
         args={{
             elementPath : 'components/button/_doc/css-only.drupal',
             class       : 'ml-4 mb-3',

--- a/projects/front-end-library/src/lib/components/carousel/_doc/doc.stories.mdx
+++ b/projects/front-end-library/src/lib/components/carousel/_doc/doc.stories.mdx
@@ -80,6 +80,7 @@ export const Drupal = (args) => ({
     <Story
         name='Drupal'
         height='800px'
+        parameters={{ options: { showPanel: false } }}
         args={{
             elementPath : 'components/carousel/_doc/template.drupal',
         }}

--- a/projects/front-end-library/src/lib/components/link/_doc/doc.stories.mdx
+++ b/projects/front-end-library/src/lib/components/link/_doc/doc.stories.mdx
@@ -90,6 +90,7 @@ export const Drupal = (args) => ({
     <Story
         name='Drupal - Examples'
         height='600px'
+        parameters={{ options: { showPanel: false } }}
         args={{
             elementPath : 'components/link/_doc/template-examples.drupal'
         }}
@@ -101,6 +102,7 @@ export const Drupal = (args) => ({
 <Canvas withSource='none'>
     <Story
         name='Drupal - CSS Only'
+        parameters={{ options: { showPanel: false } }}
         args={{
             elementPath : 'components/link/_doc/template-css-only.drupal'
         }}

--- a/projects/front-end-library/src/lib/components/selection-tile/_doc/doc.stories.mdx
+++ b/projects/front-end-library/src/lib/components/selection-tile/_doc/doc.stories.mdx
@@ -119,7 +119,7 @@ export const commonProps = {
     style={{ height: '600px' }}
 >
     <Story
-        name='Example - Selection Color'
+        name='Drupal - Example Selection Color'
         parameters={{ options: { showPanel: false } }}
         args={{
             elementPath : 'components/selection-tile/_doc/example.drupal',

--- a/projects/front-end-library/src/lib/components/selection-tile/_doc/doc.stories.mdx
+++ b/projects/front-end-library/src/lib/components/selection-tile/_doc/doc.stories.mdx
@@ -69,7 +69,7 @@ export const Drupal = (args) => ({
 export const commonProps = {
     value       : 'value',
     name        : 'name',
-    inputId     : 'intputId',
+    inputId     : 'inputId',
     ariaLabel   : 'ariaLabel',
     orientation : 'horizontal',
     fit         : 'content',
@@ -120,6 +120,7 @@ export const commonProps = {
 >
     <Story
         name='Example - Selection Color'
+        parameters={{ options: { showPanel: false } }}
         args={{
             elementPath : 'components/selection-tile/_doc/example.drupal',
             type : 'radio',

--- a/projects/front-end-library/src/lib/components/tile/_doc/doc.stories.mdx
+++ b/projects/front-end-library/src/lib/components/tile/_doc/doc.stories.mdx
@@ -64,6 +64,7 @@ export const Drupal = (args) => ({
     <Story
         name='Drupal - List example'
         height='600px'
+        parameters={{ options: { showPanel: false } }}
         args={{
             elementPath     : 'components/tile/_doc/list.drupal',
         }}

--- a/projects/front-end-library/src/lib/sections/tiles-post/_doc/doc.stories.mdx
+++ b/projects/front-end-library/src/lib/sections/tiles-post/_doc/doc.stories.mdx
@@ -212,6 +212,7 @@ export const commonProps = {
 <Canvas withSource='none'>
     <Story
         name='Drupal - Usage example'
+        parameters={{ options: { showPanel: false } }}
         height='600px'
         args={{
             elementPath: 'sections/tiles-post/_doc/template.drupal',


### PR DESCRIPTION
Composants/sections qui ont des stories qui n'affichent plus le control panel Storybook: 

Components : 
- block-highlight
- breadcrumb
- button
- button-nav
- carousel
- link
- selection-tile
- tile

Sections : 
- tiles-post