### PR TITLE
Ds 367 document raw strings as HTMLElement

### DIFF
--- a/CHANGELOG.mdx
+++ b/CHANGELOG.mdx
@@ -22,7 +22,7 @@
 - Improved [icon Illustration library](/story/components-icon--drupal-illustration) accessibility by adding `role="img"` to SVGs
 - Improved [icon Interface library](/story/components-icon--drupal-interface) accessibility by adding `role="img"` to SVGs
 
-## Tile Post
+### Tile Post
 - Remove property `image.fit`. Images always respect their ratio.
 
 ### Badge

--- a/projects/front-end-library/src/lib/components/card/angular/card.component.ts
+++ b/projects/front-end-library/src/lib/components/card/angular/card.component.ts
@@ -59,7 +59,7 @@ export class CardComponent implements OnInit {
     Note: Wrap your data with a semantic HTML tag.
     E.g. `description_html: "<p>this is a description</p>"`
     */
-    @Input() description_html       : string;
+    @Input() description_html       : HTMLElement;
     /** Expected format:
      <pre style='font-size: .75rem; padding: 0 1rem; marigin:0; background-color: #f2f2f0'>
         {

--- a/projects/front-end-library/src/lib/components/input-checkbox/angular/input-checkbox.component.ts
+++ b/projects/front-end-library/src/lib/components/input-checkbox/angular/input-checkbox.component.ts
@@ -18,7 +18,7 @@ export class InputCheckboxComponent implements OnInit {
     @Input() isInvalid: boolean;
     @Input() isRequired: boolean;
     @Input() extraAttribute: string;
-    @Input() label: string;
+    @Input() label: HTMLElement;
     @Input() labelClass: string;
     @Input() labelExtraAttribute: string;
     /** Needs to be defined if no label is defined */

--- a/projects/front-end-library/src/lib/components/price/angular/price.component.ts
+++ b/projects/front-end-library/src/lib/components/price/angular/price.component.ts
@@ -27,7 +27,7 @@ export class PriceComponent implements OnInit {
     @Input() saved                  : string;
     /** **Deprecated** Use `promotion.savedLabel` instead. */
     @Input() savedLabel             : string;
-    @Input() details                : string;
+    @Input() details                : HTMLElement;
     @Input() message                : string;
 
     @Input() size                   : 'small' | 'medium' | 'large';

--- a/projects/front-end-library/src/lib/components/selection-tile/angular/selection-tile.component.ts
+++ b/projects/front-end-library/src/lib/components/selection-tile/angular/selection-tile.component.ts
@@ -31,7 +31,7 @@ export class SelectionTileComponent implements OnInit {
     @Input() isDisabled     : boolean;
     @Input() isSelected     : boolean;
     @Input() isInvalid      : boolean;
-    @Input() errorMessage   : string;
+    @Input() errorMessage   : HTMLElement;
     @Input() isRequired     : boolean;
     @Input() content        : string | 'TwigBlock';
 

--- a/projects/front-end-library/src/lib/components/text-featured/angular/text-featured.component.ts
+++ b/projects/front-end-library/src/lib/components/text-featured/angular/text-featured.component.ts
@@ -8,7 +8,7 @@ export class TextFeaturedComponent implements OnInit {
     constructor() {}
 
     @Input() spacingLeft: number;
-    @Input() textFeatured_content: string | 'TwigBlock';
+    @Input() textFeatured_content: HTMLElement | 'TwigBlock';
     @Input() class: string;
 
     ngOnInit() {


### PR DESCRIPTION
Info: Use `HTMLElement` instead of `richText` to be more TypeScript compliant.