### PR TITLE
DS-471: Fix var causing "git push" issue on Drupal

### DIFF
--- a/projects/front-end-library/src/lib/components/link/_doc/template-css-only.drupal.twig
+++ b/projects/front-end-library/src/lib/components/link/_doc/template-css-only.drupal.twig
@@ -6,12 +6,13 @@
 {% set isUnderline = isUnderline|json_parse %}
 {% set isDisabled = isDisabled|json_parse %}
 {% set reversed = reversed|json_parse %}
+{% set hierarchyDefaultPrimary = hierarchy|default("primary") %}
 
 {# Boolean Variables #}
 {% set isDisabledTrue = isDisabled is same as(true) %}
 {% set isDisabledDefaultTrue = isDisabled|default(true) is same as(true) %}
 {% set isHierarchyPrimary = hierarchy is defined and hierarchy is same as("primary") %}
-{% set isHierarchyDefaultPrimary = hierarchy|default("primary") is defined and hierarchy|default("primary") is same as("primary") %}
+{% set isHierarchyDefaultPrimary = hierarchyDefaultPrimary is defined and hierarchyDefaultPrimary is same as("primary") %}
 
 {% set variants = [
   {


### PR DESCRIPTION
The issue was that on the Drupal project, when a dev did a `git push`, there is a validation that was giving an error on a single variable.

Here is the error : 

```
> validate:twig
Validating twig syntax for all custom modules and themes...
Iterating over fileset files.twig...

  ERROR  in [COMPUTER_PATH]/docroot/themes/custom/dxp_front/bifrost/dist/components/link/_doc/template-css-only.drupal.twig (line 14)
      12     {% set isDisabledDefaultTrue = isDisabled|default(true) is same as(true) %}
      13     {% set isHierarchyPrimary = hierarchy is defined and hierarchy is same as("primary") %}
  >>  14     {% set isHierarchyDefaultPrimary = hierarchy|default("primary") is defined and hierarchy|default("primary") is same as("primary") %}
  >> The "defined" test only works with simple variables.
      15
      16     {% set variants = [


 [WARNING] 1577 Twig files have valid syntax and 1 contain errors.


 [error]  Linting twig against fileset(s) files.twig returned a non-zero exit code.`
For troubleshooting guidance and support, see https://docs.acquia.com/blt/support/
The command failed. This often indicates a problem with your configuration. Review the command output above for more detailed errors, and consider re-running with verbose output for more information.
 [error]  Command `validate:twig ` exited with code 1.
For troubleshooting guidance and support, see https://docs.acquia.com/blt/support/
The command failed. This often indicates a problem with your configuration. Review the command output above for more detailed errors, and consider re-running with verbose output for more information.

 Your code has failed pre-push validation.

error: failed to push some refs to 'bitbucket.org:vidtiweb/videotron-dxp.git'
```