### PR TITLE
Feature - DS-488 - Hero banner custom background and text color

### DIFF
--- a/projects/front-end-library/src/lib/components/block-selection/_doc/api.stories.mdx
+++ b/projects/front-end-library/src/lib/components/block-selection/_doc/api.stories.mdx
@@ -12,7 +12,7 @@ import { ContentListsAPI, LinkAPI, TotalPriceAPI } from '../angular/api.componen
     }}
 />
 
-# Channels API
+# Block Selection API
 
 ## Table of content
 

--- a/projects/front-end-library/src/lib/components/block-selection/_doc/api.stories.mdx
+++ b/projects/front-end-library/src/lib/components/block-selection/_doc/api.stories.mdx
@@ -1,0 +1,83 @@
+import { moduleMetadata } from '@storybook/angular';
+import { ArgsTable, Meta } from '@storybook/addon-docs';
+import { ContentListsAPI, LinkAPI, TotalPriceAPI } from '../angular/api.component';
+
+<Meta
+    title='Components/Block Selection/API'
+    parameters={{
+        viewMode: 'docs',
+        previewTabs: {
+            canvas: { hidden: true }
+        },
+    }}
+/>
+
+# Channels API
+
+## Table of content
+
+- <a href="#icontentlists" target="_self">IContentLists</a>
+- <a href="#ilink" target="_self">ILink</a>
+- <a href="#itotalprice" target="_self">ITotalPrice</a>
+
+## IContentLists
+
+<h3 id="icontentlists-api">API</h3>
+
+<ArgsTable of={ContentListsAPI} />
+
+<h3 id="icontentlists-format">Expected format</h3>
+
+```jsx
+{
+    "btnDelete": {
+        "href": "/delete",
+    },
+    "btnModify": {
+        "href": "/modify",
+    },
+    "description": "Navy Blue, 128 Go",
+    "fullPrice": "$150.00",
+    "link": {
+        "href": "www.videotron.com",
+        "label": "ADD A PHONE",
+    },
+    "price": "$24.00",
+    "priceInfo": "/ month",
+    "saving": "$30.00",
+    "title": "Samsung Galaxy Note 20 Utra 5G",
+}
+```
+
+## ILink
+
+<h3 id="ilink-api">API</h3>
+
+<ArgsTable of={LinkAPI} />
+
+<h3 id="ilink-format">Expected format</h3>
+
+```jsx
+{
+    "href": "www.videotron.com",
+    "label": "ADD A PHONE",
+}
+```
+
+## ITotalPrice
+
+<h3 id="itotalprice-api">API</h3>
+
+<ArgsTable of={TotalPriceAPI} />
+
+<h3 id="itotalprice-format">Expected format</h3>
+
+```jsx
+{
+    "details": "Plus applicable taxes",
+    "label": "Total",
+    "price": "$80.00",
+    "priceDetails": "(for 24 month)",
+    "priceInfo": "/ month",
+}
+```

--- a/projects/front-end-library/src/lib/components/block-selection/_doc/data.ts
+++ b/projects/front-end-library/src/lib/components/block-selection/_doc/data.ts
@@ -29,3 +29,11 @@ export const contentListsData = [
         },
     },
 ];
+
+export const totalPriceData = {
+    details: 'Plus applicable taxes',
+    label: 'Total',
+    price: '$80.00',
+    priceDetails: '(for 24 month)',
+    priceInfo: '/ month',
+};

--- a/projects/front-end-library/src/lib/components/block-selection/_doc/doc.stories.mdx
+++ b/projects/front-end-library/src/lib/components/block-selection/_doc/doc.stories.mdx
@@ -1,6 +1,6 @@
 import { moduleMetadata } from '@storybook/angular';
 import { ArgsTable, Canvas, Meta, Story } from '@storybook/addon-docs';
-import { contentListsData } from './data';
+import { contentListsData, totalPriceData } from './data';
 import { TwigContainerComponent } from '../../../../utils/twig-container/twig-container.component';
 import { BlockSelectionComponent } from '../angular/block-selection.component';
 
@@ -82,13 +82,7 @@ export const commonProps = {
         label: 'FINALIZE',
     },
     contentLists: contentListsData,
-    totalPrice: {
-        label: 'Total',
-        details: 'Plus applicable taxes',
-        price: '$80.00',
-        priceInfo: '/ month',
-        priceDetails: '(for 24 month)',
-    },
+    totalPrice: totalPriceData,
     class: '',
 };
 
@@ -98,7 +92,6 @@ export const commonProps = {
         height="600px"
         args={{
             ...commonProps,
-            reversed: undefined,
         }}
     >
         {Drupal.bind({})}

--- a/projects/front-end-library/src/lib/components/block-selection/_doc/template.drupal.twig
+++ b/projects/front-end-library/src/lib/components/block-selection/_doc/template.drupal.twig
@@ -4,12 +4,12 @@
 {% set totalPrice = totalPrice|json_parse|default({}) %}
 {% set isCollapsableOnMobile = isCollapsableOnMobile|json_parse %}
 {% set isCollapsedByDefaultOnMobile = isCollapsedByDefaultOnMobile|json_parse %}
-{% set reversed = reversed|json_parse %}
+{% set _reversed = _reversed|json_parse %}
 
 {# Arrays of Classes With Dynamic Elements #}
 {% set mainContainerClasses = [
   "d-flex flex-column flex-sm-row justify-content-center minh-100",
-  (reversed ? "reversed bf-color-bg-ground"),
+  (_reversed ? "reversed bf-color-bg-ground"),
 ] %}
 
 {# Template #}
@@ -17,7 +17,7 @@
   {% for index in [1, 2] %}
 
     {# In Loop : Boolean Variables #}
-    {% set isReversed = index == 2 and reversed is not defined %}
+    {% set isReversed = index == 2 and _reversed is not defined %}
 
     {# In Loop : Arrays of Classes With Dynamic Elements #}
     {% set innerContainerClasses = [

--- a/projects/front-end-library/src/lib/components/block-selection/angular/api.component.ts
+++ b/projects/front-end-library/src/lib/components/block-selection/angular/api.component.ts
@@ -1,0 +1,146 @@
+import { Component, Input } from '@angular/core';
+import { IContentLists, ILink, ITotalPrice } from './api.model';
+
+@Component({
+    selector: '',
+})
+export class ContentListsAPI implements IContentLists {
+    /**
+     * <span style="color: orange;">__Optional__</span>
+     * <br><br>
+     * - It displays a button with a "garbage bin" icon.
+     * - This button takes only the `href` prop in its object,
+         so no need for the `label` prop.
+     * - If a `link` is provided, `btnDelete` won't show up.
+     */
+    @Input() btnDelete: ILink;
+    /**
+     * <span style="color: orange;">__Optional__</span>
+     * <br><br>
+     * - It displays a button with a "pencil" icon.
+     * - This button takes only the `href` prop in its object,
+         so no need for the `label` prop.
+     * - If a `link` is provided, `btnModify` won't show up.
+     */
+    @Input() btnModify: ILink;
+    /**
+     * <span style="color: orange;">__Optional__</span>
+     * <br><br>
+     * - Short description of the item.
+     * - It displays below `title`.
+     */
+    @Input() description: string;
+    /**
+     * <span style="color: orange;">__Optional__</span>
+     * <br><br>
+     * - Full price of the item.
+     * - It displays a price with a strike through it on the right side
+         of the item content, below `price` and `priceInfo`.
+     * - If `saving` is not defined, it won't show up.
+     * - If a `link` is provided, `fullPrice` won't show up.
+     */
+    @Input() fullPrice: string;
+    /**
+     * <span style="color: orange;">__Optional__</span>
+     * <br><br>
+     * - It displays a link on the right side of the item content.
+     * - If a `link` is provided, `btnDelete`, `btnModify`, `fullPrice`,
+         `price`, `priceInfo`, `saving` won't show up.
+     */
+    @Input() link: ILink;
+    /**
+     * <span style="color: orange;">__Optional__</span>
+     * <br><br>
+     * - It displays a price on the right side of the item content,
+         below `btnDelete` and `btnModify`.
+     * - If a `link` is provided, `price` won't show up.
+     */
+    @Input() price: string;
+    /**
+     * <span style="color: orange;">__Optional__</span>
+     * <br><br>
+     * - It displays a text string just after `price`.
+     * - If a `link` is provided, `priceInfo` won't show up.
+     */
+    @Input() priceInfo: string;
+    /**
+     * <span style="color: orange;">__Optional__</span>
+     * <br><br>
+     * - It displays a price in a yellow box on the right side
+         of the item content, below `price` and `priceInfo`.
+     * - If a `link` is provided, `saving` won't show up.
+     */
+    @Input() saving: string;
+    /**
+     * <span style="color: orange;">__Optional__</span>
+     * <br><br>
+     * - Title of item.
+     * - It displays a title on the left side
+         of the item content, above `description`.
+     */
+    @Input() title: string;
+}
+
+@Component({
+    selector: '',
+})
+export class LinkAPI implements ILink {
+    /**
+     * <span style="color: red;">__Required__</span>
+     * <br><br>
+     * URL of the link.
+     *
+     * @required
+     */
+    @Input() href: string;
+    /**
+     * <span style="color: orange;">__Optional__</span>
+     * <br><br>
+     * Text string of the link.
+     */
+    @Input() label: string;
+}
+
+@Component({
+    selector: '',
+})
+export class TotalPriceAPI implements ITotalPrice {
+    /**
+     * <span style="color: red;">__Required__</span>
+     * <br><br>
+     * Details / description, it displays on the left side below the `label`.
+     *
+     * @required
+     */
+    @Input() details: string;
+    /**
+     * <span style="color: red;">__Required__</span>
+     * <br><br>
+     * Title of the footer zone, it display on the left side above `details`.
+     *
+     * @required
+     */
+    @Input() label: string;
+    /**
+     * <span style="color: red;">__Required__</span>
+     * <br><br>
+     * It displays a price on the right side of the footer zone.
+     *
+     * @required
+     */
+    @Input() price: string;
+    /**
+     * <span style="color: red;">__Required__</span>
+     * <br><br>
+     * It displays details on the right side of the footer zone, below `price` and `priceInfo`.
+     *
+     * @required
+     */
+    @Input() priceDetails: string;
+    /**
+     * <span style="color: orange;">__Optional__</span>
+     * <br><br>
+     * It displays a text string just after `price`.
+     */
+    @Input() priceInfo: string;
+}

--- a/projects/front-end-library/src/lib/components/block-selection/angular/api.model.ts
+++ b/projects/front-end-library/src/lib/components/block-selection/angular/api.model.ts
@@ -1,0 +1,35 @@
+export interface IBlockSelection {
+    class?: string;
+    contentLists?: IContentLists[];
+    isCollapsableOnMobile?: boolean;
+    isCollapsedByDefaultOnMobile?: boolean;
+    title?: string;
+    titleTag?: string;
+    topLink?: ILink;
+    totalPrice?: object;
+}
+
+export interface IContentLists {
+    btnDelete?: ILink;
+    btnModify?: ILink;
+    description?: string;
+    fullPrice?: string;
+    link?: ILink;
+    price?: string;
+    priceInfo?: string;
+    saving?: string;
+    title?: string;
+}
+
+export interface ILink {
+    href: string;
+    label?: string;
+}
+
+export interface ITotalPrice {
+    details: string;
+    label: string;
+    price: string;
+    priceDetails: string;
+    priceInfo?: string;
+}

--- a/projects/front-end-library/src/lib/components/block-selection/angular/api.model.ts
+++ b/projects/front-end-library/src/lib/components/block-selection/angular/api.model.ts
@@ -6,7 +6,7 @@ export interface IBlockSelection {
     title?: string;
     titleTag?: string;
     topLink?: ILink;
-    totalPrice?: object;
+    totalPrice?: ITotalPrice;
 }
 
 export interface IContentLists {

--- a/projects/front-end-library/src/lib/components/block-selection/angular/block-selection.component.ts
+++ b/projects/front-end-library/src/lib/components/block-selection/angular/block-selection.component.ts
@@ -1,28 +1,73 @@
 import { Component, ViewEncapsulation, OnInit, Input, Output, EventEmitter } from '@angular/core';
-
-/**
- * API is the same between **Angular** and **Drupal**.
- *
- */
+import { IBlockSelection, IContentLists, ILink, ITotalPrice } from './api.model';
 
 @Component({
     selector: 'bf-block-selection',
     templateUrl: './block-selection.component.html',
-    // styleUrls: ['../common/style.scss'],
 })
-export class BlockSelectionComponent implements OnInit {
+export class BlockSelectionComponent implements IBlockSelection, OnInit {
     constructor() {}
 
-    @Input() topLink: object;
-    @Input() contentLists: object;
-    @Input() totalPrice: object;
-    @Input() isCollapsableOnMobile: boolean;
-    @Input() isCollapsedByDefaultOnMobile: boolean;
-
-    @Input() title: string;
-    @Input() titleTag: string;
+    /**
+     * <span style="color: orange;">__Optional__</span>
+     * <br><br>
+     * Custom classes on the block main element.
+     */
     @Input() class: string;
-    @Input() reversed: boolean;
+    /**
+     * <span style="color: orange;">__Optional__</span>
+     * <br><br>
+     * - List of items content separated by a line.
+     * - See `IContentLists`
+     *    <a href="/?path=/docs/components-block-selection-api--page#icontentlists-api" target="_blank">API</a>
+     *    and <a href="/?path=/docs/components-block-selection-api--page#icontentlists-format" target="_blank">expected format</a>.
+     */
+    @Input() contentLists: IContentLists[];
+    /**
+     * <span style="color: orange;">__Optional__</span>
+     * <br><br>
+     * If `true`, on mobile resolution, the content will be collapsable.
+     */
+    @Input() isCollapsableOnMobile: boolean = false;
+    /**
+     * <span style="color: orange;">__Optional__</span>
+     * <br><br>
+     * - If `true`, on mobile resolution, the content will be collapsed by default.
+     * - Only works if `isCollapsableOnMobile` is `true`.
+     */
+    @Input() isCollapsedByDefaultOnMobile: boolean = false;
+    /**
+     * <span style="color: orange;">__Optional__</span>
+     * <br><br>
+     * - It displays at the top of the component.
+     * - If `isCollapsableOnMobile` is `true`, then it will be the button's label
+         on mobile resolution.
+     */
+    @Input() title: string;
+    /**
+     * <span style="color: orange;">__Optional__</span>
+     * <br><br>
+     * This is the HTML tag used for `title`.
+     */
+    @Input() titleTag: string = 'h1';
+    /**
+     * <span style="color: orange;">__Optional__</span>
+     * <br><br>
+     * It displays on the right of `title`.
+     * - See `ILink`
+     *    <a href="/?path=/docs/components-block-selection-api--page#ilink-api" target="_blank">API</a>
+     *    and <a href="/?path=/docs/components-block-selection-api--page#ilink-format" target="_blank">expected format</a>.
+     */
+    @Input() topLink: ILink;
+    /**
+     * <span style="color: orange;">__Optional__</span>
+     * <br><br>
+     * - It displays in the footer of the component.
+     * - See `ITotalPrice`
+     *    <a href="/?path=/docs/components-block-selection-api--page#itotalprice-api" target="_blank">API</a>
+     *    and <a href="/?path=/docs/components-block-selection-api--page#itotalprice-format" target="_blank">expected format</a>.
+     */
+    @Input() totalPrice: ITotalPrice;
 
     ngOnInit() {
         console.log('block selection', this);

--- a/projects/front-end-library/src/lib/components/card/_doc/doc.stories.mdx
+++ b/projects/front-end-library/src/lib/components/card/_doc/doc.stories.mdx
@@ -19,9 +19,6 @@ import { CardComponent } from '../angular/card.component';
         isDisabled: {
             table: { defaultValue: { summary: false } },
         },
-        language: {
-            table: { defaultValue: { summary: 'en' } },
-        },
         iconName: {
             defaultValue: '',
             control: {
@@ -35,6 +32,9 @@ import { CardComponent } from '../angular/card.component';
                         .sort(),
                 ],
             },
+        },
+        language: {
+            table: { category: 'Deprecated Inputs' },
         },
     }}
 />

--- a/projects/front-end-library/src/lib/components/card/_doc/doc.stories.mdx
+++ b/projects/front-end-library/src/lib/components/card/_doc/doc.stories.mdx
@@ -227,7 +227,6 @@ and for each card type it displays a checkmark if the prop is available.
     title           : 'iPhone 12 Mini',
     subtitle        : 'Lorem ipsum subtitle',
     ...
-    }
 } only %}
 ```
 

--- a/projects/front-end-library/src/lib/components/card/angular/card.component.ts
+++ b/projects/front-end-library/src/lib/components/card/angular/card.component.ts
@@ -206,6 +206,8 @@ export class CardComponent implements OnInit {
     @Input() visualBackgroundColor: string;
 
     /**
+     * __\*Deprecated\*__
+     *
      * <span style="color: orange;">__Optional__</span>
      * <br><br>
      * - Use `price.language` instead

--- a/projects/front-end-library/src/lib/components/card/angular/card.component.ts
+++ b/projects/front-end-library/src/lib/components/card/angular/card.component.ts
@@ -120,14 +120,6 @@ export class CardComponent implements OnInit {
      */
     @Input() isDisabled: boolean;
     /**
-     * <span style="color: red;">__Required__</span>
-     * <br><br>
-     * For `price` component `language` parameter.
-     *
-     * @required
-     */
-    @Input() language: 'en' | 'fr' = 'en';
-    /**
      * <span style="color: orange;">__Optional__</span>
      * <br><br>
      * - It is displayed below the subtitle.
@@ -212,6 +204,14 @@ export class CardComponent implements OnInit {
           To test this props, use a color name like `red`, `blue`, `yellow`, `black`, etc.
      */
     @Input() visualBackgroundColor: string;
+
+    /**
+     * <span style="color: orange;">__Optional__</span>
+     * <br><br>
+     * - Use `price.language` instead
+     * - If `price.language` is not provided, it will use this prop instead.
+     */
+    @Input() language: 'en' | 'fr' = 'en';
 
     ngOnInit() {
         console.log('card', this);

--- a/projects/front-end-library/src/lib/components/card/twig/index.twig
+++ b/projects/front-end-library/src/lib/components/card/twig/index.twig
@@ -354,7 +354,7 @@
       {% set price =
         price|merge({
           class: "w-100 " ~ price.class,
-          language: language
+          language: price.language|default(language)
         })
       %}
       {% include "@bf-components/price/twig/index.twig" with price only %}

--- a/projects/front-end-library/src/lib/components/hero/_doc/api.stories.mdx
+++ b/projects/front-end-library/src/lib/components/hero/_doc/api.stories.mdx
@@ -1,0 +1,37 @@
+import { moduleMetadata } from '@storybook/angular';
+import { ArgsTable, Meta } from '@storybook/addon-docs';
+import { ImageAPI } from '../angular/api.component';
+
+<Meta
+    title='Components/Hero/API'
+    parameters={{
+        viewMode: 'docs',
+        previewTabs: {
+            canvas: { hidden: true }
+        },
+    }}
+/>
+
+# Hero API
+
+## Table of content
+
+- <a href="#iheroimage" target="_self">IHeroImage</a>
+
+## IHeroImage
+
+<h3 id="iheroimage-api">API</h3>
+
+<ArgsTable of={ImageAPI} />
+
+<h3 id="iheroimage-format">Expected format</h3>
+
+```jsx
+{
+    "alt": "Helix",
+    "isSplitted": true,
+    "lg": "/images/_docs/hero-1440x922.webp",
+    "md": "/images/_docs/hero-992x550.webp",
+    "sm": "/images/_docs/hero-575x288.webp",
+}
+```

--- a/projects/front-end-library/src/lib/components/hero/_doc/doc.stories.mdx
+++ b/projects/front-end-library/src/lib/components/hero/_doc/doc.stories.mdx
@@ -21,7 +21,13 @@ import { HeroComponent } from '../angular/hero.component';
             },
         },
         height: {
-            control: { type: 'select' },
+            control: {
+                type: 'select',
+                options: ['automatic', 'large']
+            },
+        },
+        language: {
+            table: { category: 'Deprecated Inputs' },
         },
     }}
 />

--- a/projects/front-end-library/src/lib/components/hero/_doc/doc.stories.mdx
+++ b/projects/front-end-library/src/lib/components/hero/_doc/doc.stories.mdx
@@ -51,40 +51,66 @@ import { HeroComponent } from '../angular/hero.component';
         angle: '',
         iconName: ''
     },
+    blockSelection: {
+        title: 'My selection',
+        month: 'month',
+        contentLists: [
+            {
+                description: 'Navy Blue, 128 Go',
+                fullPrice: '$150.00',
+                price: '$24.00',
+                saving: '$30.00',
+                title: 'Samsung Galaxy Note 20 Utra 5G',
+            },
+            {
+                description: 'Lorem ipsum',
+                price: '$55.00',
+                title: 'All-inclusive 12 GB Mobile',
+            }
+        ]
+    },
     breadcrumb: `<nav aria-label='breadcrumb'><ol class='breadcrumb pl-0 mb-0'><li class='breadcrumb-item'><a href=''>Home</a></li><li class='breadcrumb-item active' aria-current='page'>Library</li></ol></nav>`,
     buttons: [
         {
-            label       : 'Main action',
-            hierarchy   : '',
-            class       : ''
+            class: '',
+            hierarchy: '',
+            label: 'Main action',
         },
         {
-            label       : 'Secondary action',
-            hierarchy   : '',
-            class       : ''
+            class: '',
+            hierarchy: '',
+            label: 'Secondary action',
         }
     ],
+    class: 'my-custom-class',
+    content: '<p>The property <b>content</b> could be a string or a TwigBlock.</p>',
+    customBgColor: '#191970',
+    customFontColor: '#daa520',
     description: 'After checking to see if Helix services are available at your address, we will suggest the best Helix packages and promotions for you.',
     height: 'large',
+    icon: 'placeholder',
     image: {
-        lg      : '/images/_docs/hero-helix.png',
-        md      : '/images/_docs/hero-helix-tablet.png', // Only used if isSplitted: true
-        sm      : '/images/_docs/hero-helix-mobile.png',
-        alt     : 'Helix'
+        alt: 'Helix',
+        isSplitted: false,
+        lg: '/images/_docs/hero-helix.png',
+        md: '/images/_docs/hero-helix-tablet.png',
+        sm: '/images/_docs/hero-helix-mobile.png',
     },
     price: {
-        upperTitle      : 'From',
-        dollar          : 86,
-        cent            : 99,
-        details         : '/month',
-        promotion       : {
-            priceStriked    : 40.99,
-            priceSaved      : 10,
-            savedLabel      : 'You saved :',
-            superscript     : 1,
-            direction       : 'horizontal',
-        }
+        cent: 99,
+        details: '/month',
+        dollar: 86,
+        language: 'en',
+        promotion: {
+            direction: 'horizontal',
+            priceSaved: 10,
+            priceStriked: 40.99,
+            savedLabel: 'You saved :',
+            superscript: 1,
+        },
+        upperTitle: 'From',
     },
+    reversed: false,
     subtitle: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
     title: 'Discover our best Helix Internet and TV packages',
     upperTitle: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
@@ -139,6 +165,21 @@ export const Drupal = (args) => ({
 </Canvas>
 
 ## Drupal Example
+
+<Canvas withSource="none">
+    <Story
+        name="Drupal - With custom background and text color"
+        height="500px"
+        args={{
+            elementPath: 'components/hero/_doc/template.drupal',
+            ...commonProps,
+            customBgColor: 'midnightblue',
+            customFontColor: 'goldenrod',
+        }}
+    >
+        {Drupal.bind({})}
+    </Story>
+</Canvas>
 
 <Canvas withSource="none">
     <Story

--- a/projects/front-end-library/src/lib/components/hero/_doc/doc.stories.mdx
+++ b/projects/front-end-library/src/lib/components/hero/_doc/doc.stories.mdx
@@ -12,6 +12,9 @@ import { HeroComponent } from '../angular/hero.component';
         _imageReversed: {
             description: '**[ ! ]** This control is only used for testing a different image in the Hero reversed.',
         },
+        _reversed: {
+            table: { disable: true },
+        },
         breadcrumb: {
             table: {
                 type: { summary: 'TwigBlock' },
@@ -35,17 +38,14 @@ import { HeroComponent } from '../angular/hero.component';
 
 ```jsx
 {% include '@bf-components/hero/twig/index.twig' with {
-    badge       : {
-        label       : 'NEW',
-        hierarchy   : 'primary',
-        angle       : '',
-        iconName    : ''
+    background: 'ground',
+    badge: {
+        label: 'NEW',
+        hierarchy: 'primary',
+        angle: '',
+        iconName: ''
     },
-    breadcrumb  : `<nav aria-label='breadcrumb'><ol class='breadcrumb pl-0 mb-0'><li class='breadcrumb-item'><a href=''>Home</a></li><li class='breadcrumb-item active' aria-current='page'>Library</li></ol></nav>`,
-    upperTitle  : 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
-    title       : 'Discover our best Helix Internet and TV packages',
-    subtitle    : 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
-    description : 'After checking to see if Helix services are available at your address, we will suggest the best Helix packages and promotions for you.',
+    breadcrumb: `<nav aria-label='breadcrumb'><ol class='breadcrumb pl-0 mb-0'><li class='breadcrumb-item'><a href=''>Home</a></li><li class='breadcrumb-item active' aria-current='page'>Library</li></ol></nav>`,
     buttons: [
         {
             label       : 'Main action',
@@ -58,7 +58,15 @@ import { HeroComponent } from '../angular/hero.component';
             class       : ''
         }
     ],
-    price           : {
+    description: 'After checking to see if Helix services are available at your address, we will suggest the best Helix packages and promotions for you.',
+    height: 'large',
+    image: {
+        lg      : '/images/_docs/hero-helix.png',
+        md      : '/images/_docs/hero-helix-tablet.png', // Only used if isSplitted: true
+        sm      : '/images/_docs/hero-helix-mobile.png',
+        alt     : 'Helix'
+    },
+    price: {
         upperTitle      : 'From',
         dollar          : 86,
         cent            : 99,
@@ -71,19 +79,9 @@ import { HeroComponent } from '../angular/hero.component';
             direction       : 'horizontal',
         }
     },
-    button      : {
-        label       : 'Button',
-        hierarchy   : 'primary-alt',
-        class       : 'my-class'
-    },
-    image           : {
-        lg      : '/images/_docs/hero-helix.png',
-        md      : '/images/_docs/hero-helix-tablet.png', // Only used if isSplitted: true
-        sm      : '/images/_docs/hero-helix-mobile.png',
-        alt     : 'Helix'
-    },
-    height          : 'large',
-    background      : 'ground',
+    subtitle: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+    title: 'Discover our best Helix Internet and TV packages',
+    upperTitle: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
 } only %}
 ```
 
@@ -97,11 +95,6 @@ export const commonProps = {
         iconName: '',
     },
     breadcrumb: `<nav aria-label='breadcrumb'><ol class='breadcrumb pl-0 mb-0'><li class='breadcrumb-item'><a href=''>Home</a></li><li class='breadcrumb-item active' aria-current='page'>Library</li></ol></nav>`,
-    upperTitle: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
-    title: 'Discover our best Helix Internet and TV packages',
-    subtitle: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
-    description:
-        'After checking to see if Helix services are available at your address, we will suggest the best Helix packages and promotions for you.',
     buttons: [
         {
             label: 'Main action',
@@ -114,6 +107,11 @@ export const commonProps = {
             class: '',
         },
     ],
+    description: 'After checking to see if Helix services are available at your address, we will suggest the best Helix packages and promotions for you.',
+    reversed: undefined,
+    subtitle: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+    title: 'Discover our best Helix Internet and TV packages',
+    upperTitle: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
 };
 
 export const Drupal = (args) => ({
@@ -128,7 +126,6 @@ export const Drupal = (args) => ({
         args={{
             elementPath: 'components/hero/_doc/template.drupal',
             ...commonProps,
-            reversed: undefined,
         }}
     >
         {Drupal.bind({})}
@@ -154,7 +151,6 @@ export const Drupal = (args) => ({
                 sm: '/images/_docs/hero-helix-reversed-mobile.png',
                 alt: 'Helix',
             },
-            reversed: undefined,
         }}
     >
         {Drupal.bind({})}
@@ -179,7 +175,6 @@ export const Drupal = (args) => ({
                 alt: 'Helix',
             },
             height: 'large',
-            reversed: undefined,
         }}
     >
         {Drupal.bind({})}
@@ -207,7 +202,6 @@ export const Drupal = (args) => ({
                 alt: 'Helix',
                 isSplitted: true,
             },
-            reversed: undefined,
         }}
     >
         {Drupal.bind({})}
@@ -251,7 +245,6 @@ export const Drupal = (args) => ({
                 isSplitted: true,
             },
             height: 'large',
-            reversed: undefined,
         }}
     >
         {Drupal.bind({})}
@@ -266,7 +259,6 @@ export const Drupal = (args) => ({
             elementPath: 'components/hero/_doc/template.drupal',
             ...commonProps,
             icon: { name: 'innovation' },
-            reversed: undefined,
         }}
     >
         {Drupal.bind({})}
@@ -293,7 +285,6 @@ export const Drupal = (args) => ({
                     direction: 'vertical',
                 },
             },
-            reversed: undefined,
         }}
     >
         {Drupal.bind({})}
@@ -325,7 +316,6 @@ export const Drupal = (args) => ({
                     },
                 ],
             },
-            reversed: undefined,
         }}
     >
         {Drupal.bind({})}
@@ -340,7 +330,6 @@ export const Drupal = (args) => ({
             elementPath: 'components/hero/_doc/template.drupal',
             ...commonProps,
             content: '<p>The property <b>content</b> could be a string or a TwigBlock.</p>',
-            reversed: undefined,
         }}
     >
         {Drupal.bind({})}

--- a/projects/front-end-library/src/lib/components/hero/angular/api.component.ts
+++ b/projects/front-end-library/src/lib/components/hero/angular/api.component.ts
@@ -1,0 +1,49 @@
+import { Component, Input } from '@angular/core';
+import { IHeroImage } from './api.model';
+
+@Component({
+    selector: '',
+})
+export class ImageAPI implements IHeroImage {
+    /**
+     * <span style="color: orange;">__Optional__</span>
+     * <br><br>
+     * Alternate text of the image.
+     */
+    @Input() alt: string;
+    /**
+     * <span style="color: orange;">__Optional__</span>
+     * <br><br>
+     * - Only works if the is a `lg` image source.
+     * - If `true`, the image will be displayed on the right side of the hero on desktop resolution.
+     */
+    @Input() isSplitted: boolean;
+    /**
+     * <span style="color: red;">__Required__</span>
+     * <br><br>
+     * - This is the __large__ image source path.
+     * - It is required if you want an image on desktop resolution.
+     * - Used as a `background-image` or if `isSplitted` is `true`,
+         it will be displayed on the right side of the hero.
+     *
+     * @required
+     */
+    @Input() lg: string;
+    /**
+     * <span style="color: orange;">__Optional__</span>
+     * <br><br>
+     * - This is the __medium__ image source path.
+     * - This image will be displayed on tablet resolution between `576px` and `992px`.
+     * - This image is for a better image quality than `sm` between these resolutions.
+     */
+    @Input() md: string;
+    /**
+     * <span style="color: red;">__Required__</span>
+     * <br><br>
+     * - This is the __small__ image source path.
+     * - It is required if you want an image in mobile and tablet resolutions.
+     *
+     * @required
+     */
+    @Input() sm: string;
+}

--- a/projects/front-end-library/src/lib/components/hero/angular/api.model.ts
+++ b/projects/front-end-library/src/lib/components/hero/angular/api.model.ts
@@ -12,6 +12,8 @@ export interface IHero {
     buttons?: IButton[];
     class?: string;
     content?: HTMLElement | 'TwigBlock';
+    customBgColor?: string;
+    customFontColor?: string;
     description?: string;
     height?: 'automatic' | 'large';
     icon?: string | IIcon;

--- a/projects/front-end-library/src/lib/components/hero/angular/api.model.ts
+++ b/projects/front-end-library/src/lib/components/hero/angular/api.model.ts
@@ -1,0 +1,33 @@
+import { IBadge } from '../../badge/angular/api.model';
+import { IBlockSelection } from '../../block-selection/angular/api.model';
+import { IButton } from '../../button/angular/api.model';
+import { IIcon } from '../../icon/angular/api.model';
+import { IPrice } from '../../price/angular/api.model';
+
+export interface IHero {
+    background?: 'ground' | 'underground' | 'highlight';
+    badge?: IBadge;
+    blockSelection?: IBlockSelection | 'TwigBlock';
+    breadcrumb?: HTMLElement | 'TwigBlock';
+    buttons?: IButton[];
+    class?: string;
+    content?: HTMLElement | 'TwigBlock';
+    description?: string;
+    height?: 'automatic' | 'large';
+    icon?: string | IIcon;
+    image?: IHeroImage;
+    language?: 'en' | 'fr'; // Deprecated: Use price.language instead.
+    price?: IPrice;
+    reversed?: boolean;
+    subtitle?: string;
+    title?: string;
+    upperTitle?: string;
+}
+
+export interface IHeroImage {
+    alt?: string;
+    isSplitted?: boolean;
+    lg: string;
+    md?: string;
+    sm: string;
+}

--- a/projects/front-end-library/src/lib/components/hero/angular/hero.component.ts
+++ b/projects/front-end-library/src/lib/components/hero/angular/hero.component.ts
@@ -1,10 +1,7 @@
 import { Component, ViewEncapsulation, OnInit, Input } from '@angular/core';
 import { IPrice } from '../../price/angular/api.model';
-
-/**
- * Description of the component Hero
- *
- */
+import { IBadge } from '../../badge/angular/api.model';
+import { IBlockSelection } from '../../block-selection/angular/api.model';
 
 @Component({
     selector: 'bf-hero',
@@ -14,19 +11,38 @@ import { IPrice } from '../../price/angular/api.model';
 export class HeroComponent implements OnInit {
     constructor() {}
 
-    @Input() background: 'ground' | 'underground' | 'highlight';
     /**
-     * You can pass directly the **label** as a **string** or an **object** based on
-     * [Badge](/?path=/docs/components-badge--drupal) component API.
+     * <span style="color: orange;">__Optional__</span>
+     * <br><br>
+     * Background color of the hero.
      */
-    @Input() badge: any;
+    @Input() background: 'ground' | 'underground' | 'highlight' = 'underground';
     /**
+     * <span style="color: orange;">__Optional__</span>
+     * <br><br>
+     * - This badge displays between the `breadcrumb` and the `upperTitle`.
+     * - See Badge Component [API](/?path=/docs/components-badge--drupal).
+     */
+    @Input() badge: IBadge;
+    /**
+     * <span style="color: orange;">__Optional__</span>
+     * <br><br>
      * - Does not work if there is an `image` and `image.isSplitted: true`.
-     * - Insert the component BlockSelection.
-     * - Explore its [Component API](/?path=/docs/components-block--drupal-selection).
+     * - It displays on the right side of the hero banner.
+     * - It uses the `Block Selection` component or you can pass
+         your own content with `blockSelection` Twig block.
+     * - If you use the `Block Selection` component,
+         see its [API](/?path=/docs/components-block-selection--drupal).
      */
-    @Input() blockSelection: object | 'TwigBlock';
-    @Input() breadcrumb: string;
+    @Input() blockSelection: IBlockSelection | 'TwigBlock';
+    /**
+     * <span style="color: orange;">__Optional__</span>
+     * <br><br>
+     * - It displays at the top of the component.
+     * - You can pass your own HTML code directly with the `breadcrumb` prop
+         or you can pass it through the `breadcrumb` Twig block.
+     */
+    @Input() breadcrumb: HTMLElement | 'TwigBlock';
     /**
      * - Insert buttons (max of 2 buttons).
      * - Explore its [Component API](/?path=/docs/components-button--drupal).

--- a/projects/front-end-library/src/lib/components/hero/angular/hero.component.ts
+++ b/projects/front-end-library/src/lib/components/hero/angular/hero.component.ts
@@ -2,13 +2,15 @@ import { Component, ViewEncapsulation, OnInit, Input } from '@angular/core';
 import { IPrice } from '../../price/angular/api.model';
 import { IBadge } from '../../badge/angular/api.model';
 import { IBlockSelection } from '../../block-selection/angular/api.model';
+import { IButton } from '../../button/angular/api.model';
+import { IIcon } from '../../icon/angular/api.model';
+import { IHero, IHeroImage } from './api.model';
 
 @Component({
     selector: 'bf-hero',
     templateUrl: './hero.component.html',
-    // styleUrls: ['../scss/index.scss'],
 })
-export class HeroComponent implements OnInit {
+export class HeroComponent implements IHero, OnInit {
     constructor() {}
 
     /**
@@ -21,7 +23,7 @@ export class HeroComponent implements OnInit {
      * <span style="color: orange;">__Optional__</span>
      * <br><br>
      * - This badge displays between the `breadcrumb` and the `upperTitle`.
-     * - See Badge Component [API](/?path=/docs/components-badge--drupal).
+     * - See Badge Component [API](/?path=/docs/components-badge--drupal#component-api).
      */
     @Input() badge: IBadge;
     /**
@@ -32,44 +34,115 @@ export class HeroComponent implements OnInit {
      * - It uses the `Block Selection` component or you can pass
          your own content with `blockSelection` Twig block.
      * - If you use the `Block Selection` component,
-         see its [API](/?path=/docs/components-block-selection--drupal).
+         see its [API](/?path=/docs/components-block-selection--drupal#component-api).
      */
     @Input() blockSelection: IBlockSelection | 'TwigBlock';
     /**
      * <span style="color: orange;">__Optional__</span>
      * <br><br>
-     * - It displays at the top of the component.
+     * - It displays at the top of the component on the left side.
      * - You can pass your own HTML code directly with the `breadcrumb` prop
          or you can pass it through the `breadcrumb` Twig block.
      */
     @Input() breadcrumb: HTMLElement | 'TwigBlock';
     /**
-     * - Insert buttons (max of 2 buttons).
-     * - Explore its [Component API](/?path=/docs/components-button--drupal).
+     * <span style="color: orange;">__Optional__</span>
+     * <br><br>
+     * - It displays at the bottom of the component on the left side.
+     * - You can insert a maximum of 2 buttons.
+     * - See Button Component [API](/?path=/docs/components-button--drupal#component-api).
      */
-    @Input() buttons: Array<object>[];
-    /** Class override. */
-    @Input() class: string;
-    /** HTML string or TwigBlock. Will be displayed between the description and the buttons. */
-    @Input() content: string | 'TwigBlock';
-    @Input() description: string;
-    /** Note: height large will add a min-height of 60vh. */
-    @Input() height: '' | 'large';
+    @Input() buttons: IButton[];
     /**
-     * - You can pass directly the **name** of the icon as a **string** or an **object**
-     * based on [Icon component API](/?path=/docs/components-icon--drupal).
-     * - The **size** is always override with **huge**.
+     * <span style="color: orange;">__Optional__</span>
+     * <br><br>
+     * Custom classes on the hero main element.
      */
-    @Input() icon: any;
-    /** Add `isSplitted: true` to display the image on the right side only. */
-    @Input() image: object;
-    @Input() language: 'en' | 'fr';
-    /** [Price](/?path=/docs/components-price--drupal) component. */
+    @Input() class: string;
+    /**
+     * <span style="color: orange;">__Optional__</span>
+     * <br><br>
+     * - It displays at the bottom of the component between the `description` and the `buttons`.
+     * - You can pass your own HTML code directly with the `content` prop
+         or you can pass it through the `content` Twig block.
+     */
+    @Input() content: HTMLElement | 'TwigBlock';
+    /**
+     * <span style="color: orange;">__Optional__</span>
+     * <br><br>
+     * It displays between the `subtitle` and the `description`.
+     */
+    @Input() description: string;
+    /**
+     * <span style="color: orange;">__Optional__</span>
+     * <br><br>
+     * Height prop to `large` will add a min-height of 60vh.
+     */
+    @Input() height: 'automatic' | 'large';
+    /**
+     * <span style="color: orange;">__Optional__</span>
+     * <br><br>
+     * - It displays a huge icon on the right side of the hero.
+     * - The `icon.size` is always overrided with the value `huge`.
+     * - Two methods available:
+     *   - you can pass directly the `name` of the icon as a `string`
+     *   - or you can use the Icon Component [API](/?path=/docs/components-icon--drupal#component-api).
+     */
+    @Input() icon: string | IIcon;
+    /**
+     * <span style="color: orange;">__Optional__</span>
+     * <br><br>
+     * - It displays an image at the top of the component on mobile and tablet resolution
+         and in the background of the component on desktop resolution.
+     * - If `isSplitted` value is `true` and the `lg` format is provided, instead of being
+         in the background of the component on desktop resolution, it will be displayed on the right side.
+     * - See `IHeroImage`
+     *    <a href="/?path=/docs/components-hero-api--page#iheroimage-api" target="_blank">API</a>
+     *    and <a href="/?path=/docs/components-hero-api--page#iheroimage-format" target="_blank">expected format</a>.
+     */
+    @Input() image: IHeroImage;
+    /**
+     * <span style="color: orange;">__Optional__</span>
+     * <br><br>
+     * - It displays between the `content` and the `buttons`.
+     * - See Price Component [API](/?path=/docs/components-price--drupal#component-api).
+     */
     @Input() price: IPrice;
-    @Input() reversed: boolean;
+    /**
+     * <span style="color: orange;">__Optional__</span>
+     * <br><br>
+     * - It reverses the `background` and the text color if the prop is set as `true`.
+     * - It won't work if `customBgColor` and `customFontColor` are provided.
+     */
+    @Input() reversed: boolean = false;
+    /**
+     * <span style="color: orange;">__Optional__</span>
+     * <br><br>
+     * It displays between the `title` and the `description`.
+     */
     @Input() subtitle: string;
+    /**
+     * <span style="color: orange;">__Optional__</span>
+     * <br><br>
+     * It displays between the `upperTitle` and the `subtitle`.
+     */
     @Input() title: string;
+    /**
+     * <span style="color: orange;">__Optional__</span>
+     * <br><br>
+     * It displays between the `badge` and the `title`.
+     */
     @Input() upperTitle: string;
+
+    /**
+     * __\*Deprecated\*__
+     *
+     * <span style="color: orange;">__Optional__</span>
+     * <br><br>
+     * - Use `price.language` instead
+     * - If `price.language` is not provided, it will use this prop instead.
+     */
+    @Input() language: 'en' | 'fr' = 'en';
 
     ngOnInit() {
         console.log('Hero', this);

--- a/projects/front-end-library/src/lib/components/hero/angular/hero.component.ts
+++ b/projects/front-end-library/src/lib/components/hero/angular/hero.component.ts
@@ -130,7 +130,8 @@ export class HeroComponent implements IHero, OnInit {
     /**
      * <span style="color: orange;">__Optional__</span>
      * <br><br>
-     * - It reverses the `background` and the text color if the prop is set as `true`.
+     * - It reverses the `background` and the text color if the prop is set as `true`,
+         but not for `background` value `highlight`.
      * - If `customBgColor` is provided, the only things that will reverse is the color of
          all texts in the hero and the `background-color` of the `badge` and the first `button`.
      * - If `customFontColor` is provided, only the color of the text inside the `badge`

--- a/projects/front-end-library/src/lib/components/hero/angular/hero.component.ts
+++ b/projects/front-end-library/src/lib/components/hero/angular/hero.component.ts
@@ -70,6 +70,25 @@ export class HeroComponent implements IHero, OnInit {
     /**
      * <span style="color: orange;">__Optional__</span>
      * <br><br>
+     * - It will change the `background-color` of the hero.
+     * - Even if `background` prop is provided, this prop will have priority if a custom color is provided.
+     * - The string needs to be a color name or an hexadecimal color code (ex.: #F6F6F6).
+     * - In Storybook, there is an issue with the `#` character, so it breaks the rendering of the component.
+         To test this props, use a color name like `red`, `blue`, `yellow`, `black`, etc.
+     */
+    @Input() customBgColor: string;
+    /**
+     * <span style="color: orange;">__Optional__</span>
+     * <br><br>
+     * - It will change the text `color` of the hero.
+     * - The string needs to be a color name or an hexadecimal color code (ex.: #F6F6F6).
+     * - In Storybook, there is an issue with the `#` character, so it breaks the rendering of the component.
+         To test this props, use a color name like `red`, `blue`, `yellow`, `black`, etc.
+     */
+    @Input() customFontColor: string;
+    /**
+     * <span style="color: orange;">__Optional__</span>
+     * <br><br>
      * It displays between the `subtitle` and the `description`.
      */
     @Input() description: string;
@@ -112,7 +131,10 @@ export class HeroComponent implements IHero, OnInit {
      * <span style="color: orange;">__Optional__</span>
      * <br><br>
      * - It reverses the `background` and the text color if the prop is set as `true`.
-     * - It won't work if `customBgColor` and `customFontColor` are provided.
+     * - If `customBgColor` is provided, the only things that will reverse is the color of
+         all texts in the hero and the `background-color` of the `badge` and the first `button`.
+     * - If `customFontColor` is provided, only the color of the text inside the `badge`
+         and the first `button` will be reversed.
      */
     @Input() reversed: boolean = false;
     /**

--- a/projects/front-end-library/src/lib/components/hero/angular/hero.component.ts
+++ b/projects/front-end-library/src/lib/components/hero/angular/hero.component.ts
@@ -14,25 +14,31 @@ import { IPrice } from '../../price/angular/api.model';
 export class HeroComponent implements OnInit {
     constructor() {}
 
-    @Input() breadcrumb: string;
+    @Input() background: 'ground' | 'underground' | 'highlight';
     /**
      * You can pass directly the **label** as a **string** or an **object** based on
      * [Badge](/?path=/docs/components-badge--drupal) component API.
      */
     @Input() badge: any;
-    @Input() upperTitle: string;
-    @Input() title: string;
-    @Input() subtitle: string;
-    @Input() description: string;
+    /**
+     * - Does not work if there is an `image` and `image.isSplitted: true`.
+     * - Insert the component BlockSelection.
+     * - Explore its [Component API](/?path=/docs/components-block--drupal-selection).
+     */
+    @Input() blockSelection: object | 'TwigBlock';
+    @Input() breadcrumb: string;
     /**
      * - Insert buttons (max of 2 buttons).
      * - Explore its [Component API](/?path=/docs/components-button--drupal).
      */
     @Input() buttons: Array<object>[];
-    /** [Price](/?path=/docs/components-price--drupal) component. */
-    @Input() price: IPrice;
+    /** Class override. */
+    @Input() class: string;
     /** HTML string or TwigBlock. Will be displayed between the description and the buttons. */
     @Input() content: string | 'TwigBlock';
+    @Input() description: string;
+    /** Note: height large will add a min-height of 60vh. */
+    @Input() height: '' | 'large';
     /**
      * - You can pass directly the **name** of the icon as a **string** or an **object**
      * based on [Icon component API](/?path=/docs/components-icon--drupal).
@@ -41,22 +47,13 @@ export class HeroComponent implements OnInit {
     @Input() icon: any;
     /** Add `isSplitted: true` to display the image on the right side only. */
     @Input() image: object;
-    @Input() background: 'ground' | 'underground' | 'highlight';
-
-    /**
-     * - Does not work if there is an `image` and `image.isSplitted: true`.
-     * - Insert the component BlockSelection.
-     * - Explore its [Component API](/?path=/docs/components-block--drupal-selection).
-     */
-    @Input() blockSelection: object | 'TwigBlock';
-
-    /** Class override. */
-    @Input() class: string;
-    /** Note: height large will add a min-height of 60vh. */
-    @Input() height: '' | 'large';
-    @Input() reversed: boolean;
-
     @Input() language: 'en' | 'fr';
+    /** [Price](/?path=/docs/components-price--drupal) component. */
+    @Input() price: IPrice;
+    @Input() reversed: boolean;
+    @Input() subtitle: string;
+    @Input() title: string;
+    @Input() upperTitle: string;
 
     ngOnInit() {
         console.log('Hero', this);

--- a/projects/front-end-library/src/lib/components/hero/scss/index.scss
+++ b/projects/front-end-library/src/lib/components/hero/scss/index.scss
@@ -5,16 +5,20 @@
 * ***************************************************************************** */
 
 .bf-hero {
-  background-color: var(--bf-color-bg-underground);
+  --bf-hero-bg-color: var(--bf-color-bg-underground);
+  --bf-hero-font-color: var(--bf-color-neutral-primary);
+
+  color: var(--bf-hero-font-color);
+  background-color: var(--bf-hero-bg-color);
   background-position: center;
   background-size: cover;
 
   &--bg-ground {
-    background-color: var(--bf-color-bg-ground);
+    --bf-hero-bg-color: var(--bf-color-bg-ground);
   }
 
   &--bg-highlight {
-    background-color: var(--bf-color-bg-action-primary);
+    --bf-hero-bg-color: var(--bf-color-bg-action-primary);
   }
 
   &--height-large {

--- a/projects/front-end-library/src/lib/components/hero/twig/index.twig
+++ b/projects/front-end-library/src/lib/components/hero/twig/index.twig
@@ -21,6 +21,7 @@
 {% set isBlockBreadcrumbDefined = block("breadcrumb") is defined %}
 {% set isBlockContentDefined = block("content") is defined %}
 {% set isHeightLarge = height is defined and height is same as("large") %}
+{% set isReversed = (reversed ?? false) is same as(true) %}
 
 {# Boolean Variables - ORDER IS IMPORTANT #}
 {% set hasImageLarge = hasImage and image.lg is not empty %}
@@ -30,11 +31,12 @@
 
 {# Default Variables (Props, Controls) #}
 {% set class = class|default("") %}
+{% set language = language|default("en") %}
 
 {# Arrays of Classes With Dynamic Elements #}
 {% set heroClasses = [
   "bf-hero d-flex flex-column",
-  (reversed ? "reversed"),
+  (isReversed ? "reversed"),
   (isBackgroundGround ? "bf-hero--bg-ground"),
   (isBackgroundHighlight ? "bf-hero--bg-highlight highlight"),
   (isHeightLarge ? "bf-hero--height-large"),

--- a/projects/front-end-library/src/lib/components/hero/twig/index.twig
+++ b/projects/front-end-library/src/lib/components/hero/twig/index.twig
@@ -7,6 +7,8 @@
 {% set hasBreadcrumb = breadcrumb is defined and breadcrumb is not empty %}
 {% set hasButtons = buttons is defined and buttons is not empty %}
 {% set hasContent = content is defined and content is not empty %}
+{% set hasCustomBgColor = customBgColor is defined and customBgColor is not empty %}
+{% set hasCustomFontColor = customFontColor is defined and customFontColor is not empty %}
 {% set hasDescription = description is defined and description is not empty %}
 {% set hasIcon = icon is defined and icon is not empty %}
 {% set hasImage = image is defined and image is not empty %}
@@ -14,7 +16,6 @@
 {% set hasSubtitle = subtitle is defined and subtitle is not empty %}
 {% set hasTitle = title is defined and title is not empty %}
 {% set hasUpperTitle = upperTitle is defined and upperTitle is not empty %}
-{% set hasVisualBackgroundColor = visualBackgroundColor is defined and visualBackgroundColor is not empty %}
 {% set isBackgroundGround = background is defined and background is same as("ground") %}
 {% set isBackgroundHighlight = background is defined and background is same as("highlight") %}
 {% set isBlockBlockSelectionDefined = block("blockSelection") is defined %}
@@ -46,7 +47,8 @@
 
 {# Arrays of Styles With Dynamic Elements #}
 {% set heroStyles = [
-  (hasVisualBackgroundColor ? 'background-color: ' ~ visualBackgroundColor ~ ';'),
+  (hasCustomBgColor ? '--bf-hero-bg-color: ' ~ customBgColor ~ ';'),
+  (hasCustomFontColor ? '--bf-hero-font-color: ' ~ customFontColor ~ ';'),
   (hasImageLarge and not isImageSplitted ? "background-image: url('" ~ image.lg ~ "');"|raw),
 ] %}
 

--- a/projects/front-end-library/src/lib/components/hero/twig/index.twig
+++ b/projects/front-end-library/src/lib/components/hero/twig/index.twig
@@ -22,7 +22,7 @@
 {% set isBlockBreadcrumbDefined = block("breadcrumb") is defined %}
 {% set isBlockContentDefined = block("content") is defined %}
 {% set isHeightLarge = height is defined and height is same as("large") %}
-{% set isReversed = (reversed ?? false) is same as(true) %}
+{% set isReversed = (reversed ?? false) is same as(true) or reversed is same as("1") %}
 
 {# Boolean Variables - ORDER IS IMPORTANT #}
 {% set hasImageLarge = hasImage and image.lg is not empty %}

--- a/projects/front-end-library/src/lib/components/tab/js/index.js
+++ b/projects/front-end-library/src/lib/components/tab/js/index.js
@@ -1,5 +1,4 @@
 import $ from 'jquery';
-import 'bootstrap';
 
 /* Dom Ready */
 $(function () {
@@ -7,7 +6,6 @@ $(function () {
 
     $body.on('click', '.js-bf-tab a', function (e) {
         e.preventDefault();
-        $(this).tab('show');
         $(this).closest('.js-bf-tab').find('a').not($(this)).removeClass('active');
     });
 });


### PR DESCRIPTION
### Hero
- Add two new props in the Hero component :
  - customFontColor
  - customBgColor
- Adjust documentation
- Deprecate "language" prop
  - Only used for the price component
  - Kept for legacy purpose

### Block Selection
- Adjust documentation

### Card
- Deprecate "language" prop
  - Only used for the price component
  - Kept for legacy purpose

### Fix issue
- Fix JS "collapse" functionality
  - It seems the import of "bootstrap" caused a "double trigger" on other bootstrap JS functionalities like "collapse"

![image](https://github.com/bifrost-vui/bifrost-front-end-library/assets/128060447/7cd3ac93-2581-46fe-a78d-d5d117a4bee8)
