### PR TITLE
Feature - DS-525 - Add card variant for mobile

### DIFF
--- a/projects/front-end-library/src/lib/components/card/_doc/doc.stories.mdx
+++ b/projects/front-end-library/src/lib/components/card/_doc/doc.stories.mdx
@@ -78,6 +78,7 @@ and for each card type it displays a checkmark if the prop is available.
 | imageBadgeIconFullSize          |      |   ✓   |            |           |   ✓   |
 | inputIncrement                  |      |       |            |     ✓     |       |
 | isDisabled                      |  ✓   |   ✓   |     ✓      |     ✓     |   ✓   |
+| isTwoColsMobileVariant          |      |   ✓   |            |           |       |
 | language (DEPRECATED)           |  ✓   |   ✓   |     ✓      |     ✓     |   ✓   |
 | link                            |  ✓   |   ✓   |     ✓      |     ✓     |   ✓   |
 | message                         |  ✓   |   ✓   |     ✓      |     ✓     |   ✓   |
@@ -582,6 +583,20 @@ export const phoneCommonProps = {
             elementPath: 'components/card/_doc/template.drupal',
             _cardVariant: 'phone',
             ...phoneCommonProps,
+        }}
+    >
+        {Drupal.bind({})}
+    </Story>
+</Canvas>
+
+<Canvas withSource="none" style={{ height: '900px' }}>
+    <Story
+        name="Drupal - Phone - Two Cols Mobile Variant"
+        args={{
+            elementPath: 'components/card/_doc/template.drupal',
+            _cardVariant: 'phone',
+            ...phoneCommonProps,
+            isTwoColsMobileVariant: true,
         }}
     >
         {Drupal.bind({})}

--- a/projects/front-end-library/src/lib/components/card/_doc/template.drupal.twig
+++ b/projects/front-end-library/src/lib/components/card/_doc/template.drupal.twig
@@ -22,6 +22,7 @@
 {% set imageBadgeIconFullSize = imageBadgeIconFullSize|json_parse %}
 {% set inputIncrement = inputIncrement|json_parse %}
 {% set isDisabled = isDisabled|json_parse %}
+{% set isTwoColsMobileVariant = isTwoColsMobileVariant|json_parse %}
 {% set language = language|json_parse %}
 {% set link = link|json_parse %}
 {% set message = message|json_parse %}
@@ -50,7 +51,7 @@
 
     {# In Loop : Arrays of Classes With Dynamic Elements #}
     {% set innerContainerClasses = [
-      "flex-grow-1 d-flex align-items-center justify-content-center minh-100 p-4",
+      "flex-grow-1 d-flex align-items-center justify-content-center minh-100 p-3 p-sm-4",
       (isReversed ? "reversed bf-color-bg-ground"),
     ] %}
 

--- a/projects/front-end-library/src/lib/components/card/angular/card.component.ts
+++ b/projects/front-end-library/src/lib/components/card/angular/card.component.ts
@@ -205,6 +205,14 @@ export class CardComponent implements OnInit {
     /**
      * <span style="color: orange;">__Optional__</span>
      * <br><br>
+     * - Only available in the __phone__ card type.
+     * - Change the display of the card on mobile resolution only.
+     * - The image is in the left column and the rest is in the right column.
+     */
+    @Input() isTwoColsMobileVariant: boolean = false;
+    /**
+     * <span style="color: orange;">__Optional__</span>
+     * <br><br>
      * - It is displayed below the subtitle.
      * - See `ICardLink`
      *    <a href="/?path=/docs/components-card-api--page#icardlink-api" target="_blank">API</a>

--- a/projects/front-end-library/src/lib/components/card/scss/index.scss
+++ b/projects/front-end-library/src/lib/components/card/scss/index.scss
@@ -11,6 +11,8 @@
   --bf-card-header-bg-color: var(--bf-color-bg-underground);
 
   position: relative;
+  display: flex;
+  flex-direction: column;
   width: 100%;
   max-width: 30rem;
   height: 100%;
@@ -59,6 +61,63 @@
       }
     }
   }
+  &--two-cols-mobile {
+    &.bf-card--phone {
+      @include media-breakpoint-down(sm) {
+        flex-direction: row;
+
+        /* Left column - Image */
+        .bf-card__visual {
+          max-width: 50%;
+          padding: 0.875rem;
+        }
+
+        /* Right column - Main content */
+        .bf-card__container {
+          min-width: 11.25rem;
+          max-width: 50%;
+        }
+
+        /* Header */
+        .bf-card__header {
+          padding-top: 2rem !important;
+        }
+
+        /* Body */
+        .bf-card__body {
+          /* Details color & storage */
+          .bf-card__details {
+            gap: 0.375rem;
+
+            &__colors {
+              > * {
+                margin-left: -5px;
+              }
+            }
+          }
+        }
+
+        /* Footer */
+        .bf-card__footer {
+          .bf-price {
+            .promotion-container {
+              flex-direction: column !important;
+
+              .bf-price__promotion__infos {
+                display: block !important;
+              }
+            }
+          }
+
+          .bf-card__controls {
+            .bf-button {
+              font-size: 0.875rem;
+            }
+          }
+        }
+      }
+    }
+  }
   &.disabled {
     cursor: default;
     color: var(--bf-color-neutral-tertiary);
@@ -78,7 +137,7 @@
         --bf-icon-default-color: var(--bf-color-neutral-tertiary);
       }
     }
-    .bf-card__details-colors {
+    .bf-card__details__colors {
       opacity: 0.4;
     }
     .bf-color-neutral-secondary {
@@ -222,15 +281,23 @@
       }
     }
   }
-  &__details-colors {
-    display: flex;
-    margin-left: 4px;
-    > * {
-      width: 1rem;
-      height: 1rem;
-      margin-left: -4px;
-      border: 1px solid var(--bf-color-stroke-secondary);
-      border-radius: 50%;
+  &__details {
+    &__colors {
+      display: flex;
+      margin-left: 4px;
+      > * {
+        width: 1rem;
+        height: 1rem;
+        margin-left: -4px;
+        border: 1px solid var(--bf-color-stroke-secondary);
+        border-radius: 50%;
+      }
+    }
+    &__storage {
+      display: inline-flex;
+      flex-direction: row;
+      flex-wrap: wrap;
+      gap: 0.25rem;
     }
   }
 

--- a/projects/front-end-library/src/lib/components/card/twig/index.twig
+++ b/projects/front-end-library/src/lib/components/card/twig/index.twig
@@ -36,6 +36,7 @@
 {% set isBlockButtonsDefined = block("buttons") is defined %}
 {% set isDisabled = (isDisabled ?? false) is same as(true) %}
 {% set isImageBadgeIconFullSize = (imageBadgeIconFullSize ?? false) is same as(true) %}
+{% set isTwoColsMobileVariant = (isTwoColsMobileVariant ?? false) is same as(true) %}
 
 {# Boolean Variables - Deprecation support #}
 {% set hasImageBadgeIconDeprecationSupport = image.badgeIconName is defined and image.badgeIconName is not empty %}
@@ -58,8 +59,9 @@
 
 {# Arrays of Classes With Dynamic Elements #}
 {% set cardClasses = [
-  "bf-card d-flex flex-column",
+  "bf-card",
   (hasVisual ? "bf-card--has-visual"),
+  (isTwoColsMobileVariant ? "bf-card--two-cols-mobile"),
   (isDisabled ? "disabled"),
   (class),
 ] %}
@@ -156,314 +158,316 @@
     </div>
   {% endif %}
 
-  {# Header #}
-  <header class="bf-card__header px-3 py-4 p-sm-4">
-    {% if hasUpperTitle %}
-      <p class="mb-1">
-        {{ upperTitle }}
-      </p>
-    {% endif %}
+  <div class="bf-card__container">
+    {# Header #}
+    <header class="bf-card__header px-3 py-4 p-sm-4">
+      {% if hasUpperTitle %}
+        <p class="mb-1">
+          {{ upperTitle }}
+        </p>
+      {% endif %}
 
-    {% if hasTitle %}
-      {% embed "@bf-utils/custom-tag/twig/index.twig" with {
-        customTag: titleTag,
-        attr: {
-          "class": "h3 mt-0 mb-1"
-        },
-      } %}
-        {% block customTagContent %}
-          {% if hasTitleCategory and hasTitleDetail %}
-            <span class="d-block font-weight-light">
-              {{ title.category }}
-            </span>
-            {{ title.detail }}
-          {% else %}
-            {{ title }}
-          {% endif %}
-        {% endblock %}
-      {% endembed %}
-    {% endif %}
-
-    {% if hasSubtitle %}
-      <p class="h5 my-1">
-        {{ subtitle }}
-      </p>
-    {% endif %}
-
-    {% if hasDescription %}
-      <div class="bf-card__description">
-        {{ description_html|raw }}
-      </div>
-    {% endif %}
-
-    {% if hasLink %}
-      <a {{ macros.addAttributes({
-        "href": link.href|default(""),
-        "class": ["bf-link", link.class|default("")]|join(' ')|trim,
-      }) }}>
-        {{ link.label|default("") }}
-      </a>
-    {% endif %}
-
-    {% if hasHeaderPromoBadge %}
-      {% if headerPromoBadge is not iterable %}
-        {% set headerPromoBadge = {
-          label: headerPromoBadge
+      {% if hasTitle %}
+        {% embed "@bf-utils/custom-tag/twig/index.twig" with {
+          customTag: titleTag,
+          attr: {
+            "class": "h3 mt-0 mb-1"
+          },
         } %}
-      {% endif %}
-
-      {% set headerPromoBadge = headerPromoBadge|merge({
-          angle: headerPromoBadge.angle|default("left"),
-          class: ["bf-card__badge", headerPromoBadge.class|default("")]|join(' ')|trim,
-          hierarchy: headerPromoBadge.hierarchy|default("primary"),
-        })
-      %}
-
-      {% if hasHeaderPromoBadgeCustomBgColor %}
-        {% set headerPromoBadge = headerPromoBadge|merge({
-            customBgColor: headerPromoBadgeCustomBgColor
-          })
-        %}
-      {% endif %}
-
-      {% if hasHeaderPromoBadgeCustomFontColor %}
-        {% set headerPromoBadge = headerPromoBadge|merge({
-            customFontColor: headerPromoBadgeCustomFontColor
-          })
-        %}
-      {% endif %}
-
-      {% include "@bf-components/badge/twig/index.twig" with headerPromoBadge only %}
-    {% endif %}
-  </header>
-
-  {# Body #}
-  <div class="bf-card__body flex-grow-1">
-    {% block card_body %}
-      {% if hasContentLists %}
-        {% for list in contentLists %}
-          <div class="bf-card__content-list pt-3 mx-3 mx-sm-4">
-            {% if list.title is defined %}
-              <div class="d-flex mb-2">
-                <p class="w-60 bf-text font-weight-bold mb-0">
-                  {{ list.title }}
-                </p>
-                <p class="w-40 text-right mb-0">
-                  {{ list.description }}
-                </p>
-              </div>
+          {% block customTagContent %}
+            {% if hasTitleCategory and hasTitleDetail %}
+              <span class="d-block font-weight-light">
+                {{ title.category }}
+              </span>
+              {{ title.detail }}
+            {% else %}
+              {{ title }}
             {% endif %}
+          {% endblock %}
+        {% endembed %}
+      {% endif %}
 
-            <ul class="p-0 m-0">
-              {% for content in list.content %}
-                <li class="d-flex flex-row mb-2">
-                  {% include "@bf-components/icon/twig/index.twig" with {
-                    name: content.icon,
-                    size: small,
-                    class: "mr-2"
-                  } only %}
-                  <p class="mb-0">
-                    {{ content.label }}
+      {% if hasSubtitle %}
+        <p class="h5 my-1">
+          {{ subtitle }}
+        </p>
+      {% endif %}
+
+      {% if hasDescription %}
+        <div class="bf-card__description">
+          {{ description_html|raw }}
+        </div>
+      {% endif %}
+
+      {% if hasLink %}
+        <a {{ macros.addAttributes({
+          "href": link.href|default(""),
+          "class": ["bf-link", link.class|default("")]|join(' ')|trim,
+        }) }}>
+          {{ link.label|default("") }}
+        </a>
+      {% endif %}
+
+      {% if hasHeaderPromoBadge %}
+        {% if headerPromoBadge is not iterable %}
+          {% set headerPromoBadge = {
+            label: headerPromoBadge
+          } %}
+        {% endif %}
+
+        {% set headerPromoBadge = headerPromoBadge|merge({
+            angle: headerPromoBadge.angle|default("left"),
+            class: ["bf-card__badge", headerPromoBadge.class|default("")]|join(' ')|trim,
+            hierarchy: headerPromoBadge.hierarchy|default("primary"),
+          })
+        %}
+
+        {% if hasHeaderPromoBadgeCustomBgColor %}
+          {% set headerPromoBadge = headerPromoBadge|merge({
+              customBgColor: headerPromoBadgeCustomBgColor
+            })
+          %}
+        {% endif %}
+
+        {% if hasHeaderPromoBadgeCustomFontColor %}
+          {% set headerPromoBadge = headerPromoBadge|merge({
+              customFontColor: headerPromoBadgeCustomFontColor
+            })
+          %}
+        {% endif %}
+
+        {% include "@bf-components/badge/twig/index.twig" with headerPromoBadge only %}
+      {% endif %}
+    </header>
+
+    {# Body #}
+    <div class="bf-card__body flex-grow-1">
+      {% block card_body %}
+        {% if hasContentLists %}
+          {% for list in contentLists %}
+            <div class="bf-card__content-list pt-3 mx-3 mx-sm-4">
+              {% if list.title is defined %}
+                <div class="d-flex mb-2">
+                  <p class="w-60 bf-text font-weight-bold mb-0">
+                    {{ list.title }}
                   </p>
-                </li>
-              {% endfor %}
-            </ul>
+                  <p class="w-40 text-right mb-0">
+                    {{ list.description }}
+                  </p>
+                </div>
+              {% endif %}
 
-            {% if list.channels is not empty %}
-              <div class="bf-card__channels">
-                {% if list.channels.limited is not empty %}
-                  {% include "@bf-components/channels/twig/index.twig" with {
-                    channelsData: list.channels.limited,
-                    class: "mt-2",
-                    size: "small",
-                  } only %}
-                {% endif %}
-
-                {% if list.channels.full is not empty %}
-                  {% set tabsNavItems = [] %}
-                  {% for channelsFull in list.channels.full %}
-                    {% set tabsNavItems = tabsNavItems|merge([channelsFull.tabData]) %}
-                  {% endfor %}
-
-                  <div class="mt-2">
-                    {% include "@bf-components/link/twig/index.twig" with {
-                        dataTarget: "#channelsListModal" ~ idAsSuffix,
-                        dataToggle: "modal",
-                        href: "#channelsListModal" ~ idAsSuffix,
-                        label: "See Channels"|t,
+              <ul class="p-0 m-0">
+                {% for content in list.content %}
+                  <li class="d-flex flex-row mb-2">
+                    {% include "@bf-components/icon/twig/index.twig" with {
+                      name: content.icon,
+                      size: small,
+                      class: "mr-2"
                     } only %}
-                  </div>
-                  {% embed "@bf-components/modal/twig/index.twig" with {
-                      class: "bf-card__channels__modal pr-3 pr-md-0",
-                      id: "channelsListModal" ~ idAsSuffix,
-                  } %}
-                    {% block modal_header %}
-                      <div class="w-100 text-left">
-                        <p class="modal-title">
-                          {{ "List of channels"|t }}
-                        </p>
-                      </div>
-                      {% include "@bf-components/tab/twig/real-tab.twig" with {
-                        navItems: tabsNavItems,
-                        itemClass: "bf-font-size-5 font-weight-normal",
+                    <p class="mb-0">
+                      {{ content.label }}
+                    </p>
+                  </li>
+                {% endfor %}
+              </ul>
+
+              {% if list.channels is not empty %}
+                <div class="bf-card__channels">
+                  {% if list.channels.limited is not empty %}
+                    {% include "@bf-components/channels/twig/index.twig" with {
+                      channelsData: list.channels.limited,
+                      class: "mt-2",
+                      size: "small",
+                    } only %}
+                  {% endif %}
+
+                  {% if list.channels.full is not empty %}
+                    {% set tabsNavItems = [] %}
+                    {% for channelsFull in list.channels.full %}
+                      {% set tabsNavItems = tabsNavItems|merge([channelsFull.tabData]) %}
+                    {% endfor %}
+
+                    <div class="mt-2">
+                      {% include "@bf-components/link/twig/index.twig" with {
+                          dataTarget: "#channelsListModal" ~ idAsSuffix,
+                          dataToggle: "modal",
+                          href: "#channelsListModal" ~ idAsSuffix,
+                          label: "See Channels"|t,
                       } only %}
-                    {% endblock %}
+                    </div>
+                    {% embed "@bf-components/modal/twig/index.twig" with {
+                        class: "bf-card__channels__modal pr-3 pr-md-0",
+                        id: "channelsListModal" ~ idAsSuffix,
+                    } %}
+                      {% block modal_header %}
+                        <div class="w-100 text-left">
+                          <p class="modal-title">
+                            {{ "List of channels"|t }}
+                          </p>
+                        </div>
+                        {% include "@bf-components/tab/twig/real-tab.twig" with {
+                          navItems: tabsNavItems,
+                          itemClass: "bf-font-size-5 font-weight-normal",
+                        } only %}
+                      {% endblock %}
 
-                    {% block modal_body_scroll_container %}
+                      {% block modal_body_scroll_container %}
 
-                      {# Import macros #}
-                      {% import "@bf-utils/macros/twig/index.twig" as macros %}
+                        {# Import macros #}
+                        {% import "@bf-utils/macros/twig/index.twig" as macros %}
 
-                      <div class="bf-tab-content tab-content">
-                        {% for channelsFull in list.channels.full %}
-                          {% set tabContentClasses = [
-                            "tab-pane fade",
-                            (channelsFull.tabContent.class),
-                          ] %}
+                        <div class="bf-tab-content tab-content">
+                          {% for channelsFull in list.channels.full %}
+                            {% set tabContentClasses = [
+                              "tab-pane fade",
+                              (channelsFull.tabContent.class),
+                            ] %}
 
-                          <div {{ macros.addAttributes({
-                            "aria-labelledby": channelsFull.tabContent.ariaLabelledby,
-                            "class": tabContentClasses|join(' ')|trim,
-                            "id": channelsFull.tabContent.id,
-                            "role": "tabpanel",
-                          }) }}>
-                            <div class="mt-2">
-                              {{ channelsFull.tabContent.description|raw }}
+                            <div {{ macros.addAttributes({
+                              "aria-labelledby": channelsFull.tabContent.ariaLabelledby,
+                              "class": tabContentClasses|join(' ')|trim,
+                              "id": channelsFull.tabContent.id,
+                              "role": "tabpanel",
+                            }) }}>
+                              <div class="mt-2">
+                                {{ channelsFull.tabContent.description|raw }}
+                              </div>
+                              {% include "@bf-components/channels/twig/index.twig" with {
+                                channelsData: channelsFull.tabContent.channelsList,
+                                size: "large",
+                              } only %}
                             </div>
-                            {% include "@bf-components/channels/twig/index.twig" with {
-                              channelsData: channelsFull.tabContent.channelsList,
-                              size: "large",
-                            } only %}
-                          </div>
-                        {% endfor %}
-                      </div>
-                    {% endblock %}
-                  {% endembed %}
-                {% endif %}
-              </div>
-            {% endif %}
-          </div>
-        {% endfor %}
-      {% endif %}
-
-      {% if hasDetailsColors or hasDetailsStorage %}
-        <div class="d-flex mx-3 mx-sm-4">
-          {% if hasDetailsColors %}
-            <ul class="bf-card__details-colors list-unstyled d-flex mb-0 mr-2">
-              {% for color in detailsColors|default([]) %}
-                <li {{ macros.addAttributes({
-                  "style": "background-color: #" ~ color.value,
-                  "title": "Color " ~ color.name,
-                }) }}>
-                  <span class="sr-only">
-                    Color {{ color.name }}
-                  </span>
-                </li>
-              {% endfor %}
-            </ul>
-          {% endif %}
-
-          {% if hasDetailsStorage %}
-            <p class="small mb-0">
-              {% for stockage in detailsStorage|default([]) %}
-                <span class="font-weight-bold">
-                  {{ stockage }}
-                </span>
-                {% if loop.last is same as(false) %}/{% endif %}
-              {% endfor %}
-            </p>
-          {% endif %}
-        </div>
-      {% endif %}
-
-      {% if hasContentBadges %}
-        <div class="bf-card__content-badge mt-3 mx-3 mx-sm-4">
-          {% for contentBadge in contentBadges %}
-            {% set contentBadge =
-              contentBadge|merge({
-                hierarchy: "tertiary"
-              })
-            %}
-            {% include "@bf-components/badge/twig/index.twig" with contentBadge only %}
-          {% endfor %}
-        </div>
-      {% endif %}
-
-      {% if hasPromotionBadges %}
-        <div class="bf-card__content-badge bf-card__content-badge--promotion mt-3 mx-3 mx-sm-4">
-          {% for promotionBadge in promotionBadges %}
-            {% include "@bf-components/badge/twig/index.twig" with {
-              label: promotionBadge.label,
-              iconName: promotionBadge.iconName,
-              hierarchy: "tertiary-ground",
-              isRounded: true
-            } only %}
-          {% endfor %}
-        </div>
-      {% endif %}
-    {% endblock %}
-  </div>
-
-  {# Footer #}
-  <footer class="bf-card__footer pt-0 mx-3 mx-sm-4 mb-3 mb-sm-4 mt-3">
-    {% if hasPrice %}
-      {% set price =
-        price|merge({
-          class: "w-100 " ~ price.class,
-          language: price.language|default(language)
-        })
-      %}
-      {% include "@bf-components/price/twig/index.twig" with price only %}
-    {% endif %}
-
-    {% if hasNote %}
-      <div class="small bf-color-neutral-secondary mb-0">
-        {{ note|raw }}
-      </div>
-    {% endif %}
-
-    {% if hasInputIncrement %}
-      <div class="bf-card__controls">
-        {% include "@bf-components/input-increment/twig/index.twig" with inputIncrement only %}
-      </div>
-    {% endif %}
-
-    {% if isBlockButtonsDefined or hasButtons %}
-      <div class="bf-card__controls">
-        {% if isBlockButtonsDefined %}
-          {{ block("buttons") }}
-        {% else %}
-          {% for button in buttons %}
-            {% set button =
-              button|merge({
-                class: "w-100 " ~ button.class
-              })
-            %}
-            {% include "@bf-components/button/twig/index.twig" with button only %}
+                          {% endfor %}
+                        </div>
+                      {% endblock %}
+                    {% endembed %}
+                  {% endif %}
+                </div>
+              {% endif %}
+            </div>
           {% endfor %}
         {% endif %}
-      </div>
-    {% endif %}
 
-    {% if hasMessage or hasMessageLink %}
-      <div class="bf-card__message d-flex">
-        {% include "@bf-components/icon/twig/index.twig" with {
-          name: "information-circle-filled",
-          size: "small",
-          class: "mr-2"
-        } only %}
-        <p class="mb-0">
-          {{ message }}
-          {% if hasMessageLink %}
-            <a {{ macros.addAttributes({
-              "href": messageLink.href|default("#"),
-              "class": messageLinkClasses|join(' ')|trim,
-            }) }}>
-              {{ messageLink.label|default("") }}
-            </a>
+        {% if hasDetailsColors or hasDetailsStorage %}
+          <div class="bf-card__details d-flex gap-2 mx-3 mx-sm-4">
+            {% if hasDetailsColors %}
+              <ul class="bf-card__details__colors list-unstyled d-flex mb-0">
+                {% for color in detailsColors|default([]) %}
+                  <li {{ macros.addAttributes({
+                    "style": "background-color: #" ~ color.value,
+                    "title": "Color " ~ color.name,
+                  }) }}>
+                    <span class="sr-only">
+                      Color {{ color.name }}
+                    </span>
+                  </li>
+                {% endfor %}
+              </ul>
+            {% endif %}
+
+            {% if hasDetailsStorage %}
+              <p class="bf-card__details__storage small mb-0">
+                {% for stockage in detailsStorage|default([]) %}
+                  <span class="font-weight-bold">
+                    {{- stockage -}}
+                  </span>
+                  {% if loop.last is same as(false) %}<span>/</span>{% endif %}
+                {% endfor %}
+              </p>
+            {% endif %}
+          </div>
+        {% endif %}
+
+        {% if hasContentBadges %}
+          <div class="bf-card__content-badge mt-3 mx-3 mx-sm-4">
+            {% for contentBadge in contentBadges %}
+              {% set contentBadge =
+                contentBadge|merge({
+                  hierarchy: "tertiary"
+                })
+              %}
+              {% include "@bf-components/badge/twig/index.twig" with contentBadge only %}
+            {% endfor %}
+          </div>
+        {% endif %}
+
+        {% if hasPromotionBadges %}
+          <div class="bf-card__content-badge bf-card__content-badge--promotion mt-3 mx-3 mx-sm-4">
+            {% for promotionBadge in promotionBadges %}
+              {% include "@bf-components/badge/twig/index.twig" with {
+                label: promotionBadge.label,
+                iconName: promotionBadge.iconName,
+                hierarchy: "tertiary-ground",
+                isRounded: true
+              } only %}
+            {% endfor %}
+          </div>
+        {% endif %}
+      {% endblock %}
+    </div>
+
+    {# Footer #}
+    <footer class="bf-card__footer pt-0 mx-3 mx-sm-4 mb-3 mb-sm-4 mt-3">
+      {% if hasPrice %}
+        {% set price =
+          price|merge({
+            class: "w-100 " ~ price.class,
+            language: price.language|default(language)
+          })
+        %}
+        {% include "@bf-components/price/twig/index.twig" with price only %}
+      {% endif %}
+
+      {% if hasNote %}
+        <div class="small bf-color-neutral-secondary mb-0">
+          {{ note|raw }}
+        </div>
+      {% endif %}
+
+      {% if hasInputIncrement %}
+        <div class="bf-card__controls">
+          {% include "@bf-components/input-increment/twig/index.twig" with inputIncrement only %}
+        </div>
+      {% endif %}
+
+      {% if isBlockButtonsDefined or hasButtons %}
+        <div class="bf-card__controls">
+          {% if isBlockButtonsDefined %}
+            {{ block("buttons") }}
+          {% else %}
+            {% for button in buttons %}
+              {% set button =
+                button|merge({
+                  class: "w-100 " ~ button.class
+                })
+              %}
+              {% include "@bf-components/button/twig/index.twig" with button only %}
+            {% endfor %}
           {% endif %}
-        </p>
-      </div>
-    {% endif %}
-  </footer>
+        </div>
+      {% endif %}
+
+      {% if hasMessage or hasMessageLink %}
+        <div class="bf-card__message d-flex">
+          {% include "@bf-components/icon/twig/index.twig" with {
+            name: "information-circle-filled",
+            size: "small",
+            class: "mr-2"
+          } only %}
+          <p class="mb-0">
+            {{ message }}
+            {% if hasMessageLink %}
+              <a {{ macros.addAttributes({
+                "href": messageLink.href|default("#"),
+                "class": messageLinkClasses|join(' ')|trim,
+              }) }}>
+                {{ messageLink.label|default("") }}
+              </a>
+            {% endif %}
+          </p>
+        </div>
+      {% endif %}
+    </footer>
+  </div>
 </article>

--- a/projects/front-end-library/src/lib/components/card/twig/phone.twig
+++ b/projects/front-end-library/src/lib/components/card/twig/phone.twig
@@ -18,6 +18,7 @@
   imageBadgeIconCustomFontColor: imageBadgeIconCustomFontColor|default(null),
   imageBadgeIconFullSize: imageBadgeIconFullSize|default(null),
   isDisabled: isDisabled ?? false,
+  isTwoColsMobileVariant: isTwoColsMobileVariant|default(null),
   language: language|default("en"),
   link: link|default(null),
   message: message|default(null),

--- a/projects/front-end-library/src/lib/components/price/twig/index.twig
+++ b/projects/front-end-library/src/lib/components/price/twig/index.twig
@@ -157,13 +157,13 @@
       </div>
 
       {% if hasPromotion %}
-        <div class="d-flex flex-column justify-content-center">
+        <div class="bf-price__promotion d-flex flex-column justify-content-center">
           {% if hasPromotionTitle %}
             <p class="small mb-1">
               {{ promotion.title }}
             </p>
           {% endif %}
-          <div class="d-inline-flex">
+          <div class="bf-price__promotion__infos d-inline-flex">
             {% if hasPromotionPriceStriked %}
               <p class="small text-strike mr-2 mb-0">
                 {%- set priceStrikedValue = macros.formatDecimalNumberToLanguage(promotion.priceStriked, language) -%}


### PR DESCRIPTION
# Description

- [See the component on Storybook ](https://bifrost-front-end-library-git-feature-ds-525-e27112-bifrost-vui.vercel.app/?path=/story/components-card--drupal-phone-two-cols-mobile-variant)
- [See the component in a tab outside of Storybook to better see the mobile resolution](https://bifrost-front-end-library-git-feature-ds-525-e27112-bifrost-vui.vercel.app/api/twig?elementPath=components/card/_doc/template.drupal&isTwoColsMobileVariant=true&&imageBadgeIconFullSize=false&isDisabled=false&_cardVariant=phone&buttons=%5B%7B%22hierarchy%22:%22primary-alt%22,%22href%22:%22https://www.videotron.com%22,%22label%22:%22Configurate%22%7D%5D&contentBadges=%5B%7B%22iconName%22:%22credit-return%22,%22label%22:%22credit%20return%22%7D,%7B%22iconName%22:%22check-circle-outline%22,%22label%22:%22refurbish%20available%22%7D%5D&detailsColors=%5B%7B%22name%22:%22Lorem%22,%22value%22:%224B4A46%22%7D,%7B%22name%22:%22Ipsum%22,%22value%22:%222C4651%22%7D,%7B%22name%22:%22Dolor%22,%22value%22:%22D4BBA5%22%7D,%7B%22name%22:%22Amet%22,%22value%22:%22C0C0C0%22%7D%5D&detailsStorage=%5B%22128%20Go%22,%22256%20Go%22%5D&headerPromoBadge=%7B%22iconName%22:%22payment%22,%22label%22:%22Promotion%22%7D&image=%7B%22alt%22:%22iPhone%2012%20Mini%22,%22src%22:%22/images/_docs/iphone-12-pro-max.png%22%7D&imageBadgeIcon=%7B%22name%22:%22security%22%7D&note=Plan%20+%20Phone:%20from%20$150/month%20(24%20months)%3Cbr/%3ENo%20upfront%20payment&price=%7B%22cent%22:%2299%22,%22details%22:%22/month%22,%22dollar%22:%2286%22,%22language%22:%22en%22,%22promotion%22:%7B%22direction%22:%22horizontal%22,%22priceSaved%22:%2210.00%22,%22priceStriked%22:%2240.99%22,%22savedLabel%22:%22You%20saved%20:%22,%22superscript%22:%221%22,%22title%22:%22%3Cb%3EPromotion%3C/b%3E%20test%22%7D,%22upperTitle%22:%22From%22%7D&promotionBadges=%5B%7B%22iconName%22:%22%22,%22label%22:%22Free%20Galaxy%20Buds%20Live%22%7D,%7B%22iconName%22:%22credit-welcome%22,%22label%22:%220$%20Welcome%20credit%22%7D%5D&subtitle=Discover%20the%20power%20of%20the%20phone&title=iPhone%2012%20Mini&)

### Components

#### Card
- Add a two columns variant on mobile only for `phone` card type

# Screenshots

## Screen of `320px` wide
![image](https://github.com/bifrost-vui/bifrost-front-end-library/assets/128060447/3b006cbd-bdfc-4e0c-92b7-1f4f5ea29c68)

## Screen of `375px` wide
![image](https://github.com/bifrost-vui/bifrost-front-end-library/assets/128060447/f94debe7-7099-4ced-b521-1325e32e1d03)

## Screen of `425px` wide
![image](https://github.com/bifrost-vui/bifrost-front-end-library/assets/128060447/f617d418-7d8e-4887-a004-120fc92e6dec)

## Screen of `576px` wide
![image](https://github.com/bifrost-vui/bifrost-front-end-library/assets/128060447/30179fd2-9f76-48fd-bd72-b0005e4c596f)



