### PR TITLE
DS-544: Fix phone card by modifying CSS style

### DIFF
--- a/projects/front-end-library/src/lib/components/card/_doc/doc.stories.mdx
+++ b/projects/front-end-library/src/lib/components/card/_doc/doc.stories.mdx
@@ -680,6 +680,19 @@ export const phoneCommonProps = {
     </Story>
 </Canvas>
 
+<Canvas withSource="none" style={{ height: '900px' }}>
+    <Story
+        name="Drupal - Phone - Group"
+        args={{
+            elementPath: 'components/card/_doc/template.group.drupal',
+            ...phoneCommonProps,
+            _cardVariant: 'phone',
+        }}
+    >
+        {Drupal.bind({})}
+    </Story>
+</Canvas>
+
 ### Protection card
 
 export const protectionCommonProps = {
@@ -747,6 +760,19 @@ export const protectionCommonProps = {
             _cardVariant: 'protection',
             ...protectionCommonProps,
             ...customColorsProps,
+        }}
+    >
+        {Drupal.bind({})}
+    </Story>
+</Canvas>
+
+<Canvas withSource="none" style={{ height: '900px' }}>
+    <Story
+        name="Drupal - Protection - Group"
+        args={{
+            elementPath: 'components/card/_doc/template.group.drupal',
+            _cardVariant: 'protection',
+            ...protectionCommonProps,
         }}
     >
         {Drupal.bind({})}
@@ -823,6 +849,19 @@ export const incrementCommonProps = {
             _cardVariant: 'increment',
             ...incrementCommonProps,
             ...customColorsProps,
+        }}
+    >
+        {Drupal.bind({})}
+    </Story>
+</Canvas>
+
+<Canvas withSource="none" style={{ height: '900px' }}>
+    <Story
+        name="Drupal - Increment - Group"
+        args={{
+            elementPath: 'components/card/_doc/template.group.drupal',
+            _cardVariant: 'increment',
+            ...incrementCommonProps,
         }}
     >
         {Drupal.bind({})}
@@ -913,6 +952,19 @@ export const comboCommonProps = {
             _cardVariant: 'combo',
             ...comboCommonProps,
             ...customColorsProps,
+        }}
+    >
+        {Drupal.bind({})}
+    </Story>
+</Canvas>
+
+<Canvas withSource="none" style={{ height: '900px' }}>
+    <Story
+        name="Drupal - Combo - Group"
+        args={{
+            elementPath: 'components/card/_doc/template.group.drupal',
+            _cardVariant: 'combo',
+            ...comboCommonProps,
         }}
     >
         {Drupal.bind({})}

--- a/projects/front-end-library/src/lib/components/card/scss/index.scss
+++ b/projects/front-end-library/src/lib/components/card/scss/index.scss
@@ -32,7 +32,7 @@
   &__container {
     display: flex;
     flex-direction: column;
-    height: 100%;
+    flex-grow: 1;
   }
 
   &--has-visual .bf-card__header {


### PR DESCRIPTION
### Bugs fixes

#### Card
- Fix phone type card image by changing `height: 100%` by `flex-grow: 1` on class `.bf-card__container`.

## Screenshots

### Before
![image](https://github.com/bifrost-vui/bifrost-front-end-library/assets/128060447/798654b0-120f-412d-a68b-e69b8973e302)

### After
![image](https://github.com/bifrost-vui/bifrost-front-end-library/assets/128060447/baa35440-dfe2-40f5-ba17-39675f3e6c13)
