### PR TITLE
DWN-44216: Fix the accordion of the filter component.

### DIFF
--- a/projects/front-end-library/src/lib/components/accordion/twig/index.twig
+++ b/projects/front-end-library/src/lib/components/accordion/twig/index.twig
@@ -134,6 +134,9 @@
   } %}
     {% block customTagContent %}
 
+      {# Import macros #}
+      {% import "@bf-utils/macros/twig/index.twig" as macros %}
+
       <button {{ macros.addAttributes({
         "type": "button",
         "class": accordionHeaderButtonClasses|join(' ')|trim,
@@ -153,7 +156,7 @@
 
         {% if isBlockEmphasisBlockDefined %}
           <div class="{{ accordionHeaderEmphasisClasses|join(' ')|trim }}">
-            {{ blockEmphasis }}
+            {{ blockEmphasis|raw }}
           </div>
         {% elseif hasEmphasis %}
           <div class="{{ accordionHeaderEmphasisClasses|join(' ')|trim }}">

--- a/projects/front-end-library/src/lib/components/filter/twig/index.twig
+++ b/projects/front-end-library/src/lib/components/filter/twig/index.twig
@@ -1,6 +1,3 @@
-{# Import macros #}
-{% import "@bf-utils/macros/twig/index.twig" as macros %}
-
 {# Default Variables (Props, Controls) - Pre Boolean Variables #}
 {% set numberOfCheckboxesToDisplay = numberOfCheckboxesToDisplay|default(8) %}
 
@@ -66,6 +63,9 @@
     {% endblock %}
 
     {% block contentBlock %}
+
+      {# Import macros #}
+      {% import "@bf-utils/macros/twig/index.twig" as macros %}
 
       {# Checkboxes filter #}
       {% if hasDataCheckboxes %}


### PR DESCRIPTION
When creating a 'Mobiles Filter' block, we are encountering a display issue with the accordion and buttons within the filter component (see screenshot below).

![Capture d’écran, le 2024-03-19 à 16 53 45](https://github.com/bifrost-vui/bifrost-front-end-library/assets/162147454/eec43f9d-d850-408c-b6bd-b8ce7c061d3b)

